### PR TITLE
Dev/workflow

### DIFF
--- a/dandelion_commons/src/lib.rs
+++ b/dandelion_commons/src/lib.rs
@@ -72,6 +72,8 @@ pub enum DandelionError {
     PromiseDroppedDebt,
     /// there was a non recoverable issue when spawning or running the MMU worker
     MmuWorkerError,
+    /// invalid WorkToDos
+    InvalidWorkToDo,
     // system engine errors
     /// The arguments in the context handed to the system function are malformed or otherwise insufissient
     /// the string identifies the argument that was malformed or gives other information about the issue
@@ -82,6 +84,8 @@ pub enum DandelionError {
     SystemFuncResponseError,
     /// Tried to call parser for system function
     CalledSystemFuncParser,
+    /// Can't post or subscribe data from other Dandelion server
+    PostDataError(String),
     // dispatcher errors
     /// dispatcher does not find a loader for this engine type
     DispatcherMissingLoader(String),

--- a/dandelion_commons/src/records.rs
+++ b/dandelion_commons/src/records.rs
@@ -42,6 +42,14 @@ pub enum RecordPoint {
     EngineEnd,
     /// Return from execution engine
     FutureReturn,
+    /// queue to post data
+    PostDataQueue,
+    /// start post data
+    PostDataStart,
+    /// end post data
+    PostDataEnd,
+    /// return post data
+    PostDataReturn,
     /// Send response back to the client
     EndService,
 }

--- a/dispatcher/src/function_registry.rs
+++ b/dispatcher/src/function_registry.rs
@@ -139,7 +139,7 @@ impl FunctionRegistry {
                 // get the config from the parser
                 let function_config = driver
                     .parse_function(
-                        String::from(""),
+                        String::from(system_function.to_string()),
                         *domains.get(type_map.get(engine_type).unwrap()).unwrap(),
                     )
                     .unwrap();

--- a/dispatcher/src/function_registry.rs
+++ b/dispatcher/src/function_registry.rs
@@ -139,7 +139,7 @@ impl FunctionRegistry {
                 // get the config from the parser
                 let function_config = driver
                     .parse_function(
-                        String::from(system_function.to_string()),
+                        system_function.to_string(),
                         *domains.get(type_map.get(engine_type).unwrap()).unwrap(),
                     )
                     .unwrap();

--- a/machine_interface/Cargo.toml
+++ b/machine_interface/Cargo.toml
@@ -38,6 +38,7 @@ bytes = { version = "1.6", optional = true}
 libloading = { version = "0.8.1" }
 log = "0.4.20"
 bson = "2.9.0"
+bincode = "1.3.3"
 
 # disable benchmarks in library, to not run all unit tests on every benchmark
 # also needs to be disabled for criterion flags to work that are not available for tests

--- a/machine_interface/Cargo.toml
+++ b/machine_interface/Cargo.toml
@@ -37,6 +37,7 @@ http = { version = "1.1", optional = true }
 bytes = { version = "1.6", optional = true}
 libloading = { version = "0.8.1" }
 log = "0.4.20"
+bson = "2.9.0"
 
 # disable benchmarks in library, to not run all unit tests on every benchmark
 # also needs to be disabled for criterion flags to work that are not available for tests

--- a/machine_interface/src/function_driver.rs
+++ b/machine_interface/src/function_driver.rs
@@ -1,6 +1,5 @@
 use crate::{
-    memory_domain::{Context, MemoryDomain},
-    DataRequirementList, Position,
+    memory_domain::{Context, MemoryDomain}, DataRequirementList, DataSet, Position
 };
 extern crate alloc;
 use alloc::sync::Arc;
@@ -29,13 +28,31 @@ pub struct ElfConfig {
 #[derive(Clone, Copy)]
 pub enum SystemFunction {
     HTTP,
+    SEND,
+    RECV
 }
 
 impl core::fmt::Display for SystemFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> core::fmt::Result {
         return match self {
             SystemFunction::HTTP => write!(f, "HTTP"),
+            SystemFunction::SEND => write!(f, "SEND"),
+            SystemFunction::RECV => write!(f, "RECV")
         };
+    }
+}
+
+impl core::str::FromStr for SystemFunction {
+
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "HTTP" => Ok(SystemFunction::HTTP),
+            "SEND" => Ok(SystemFunction::SEND),
+            "RECV" => Ok(SystemFunction::RECV),
+            _ => Err(format!("'{}' is not a valid SystemFunction", s)),
+        }
     }
 }
 
@@ -91,6 +108,14 @@ pub enum ComputeResource {
     GPU(u8),
 }
 
+pub enum ReqwestWorkToDo {
+    PostData{
+        id: String,
+        content: DataSet,
+        binary: Vec<u8>
+    }
+}
+
 pub enum WorkToDo {
     FunctionArguments {
         config: FunctionConfig,
@@ -115,6 +140,10 @@ pub enum WorkToDo {
         static_domain: &'static dyn MemoryDomain,
         recorder: Recorder,
     },
+    Reqwest {
+        work: ReqwestWorkToDo,
+        recorder: Recorder,
+    },
     Shutdown(),
 }
 
@@ -122,6 +151,7 @@ pub enum WorkDone {
     Context(Context),
     Function(Function),
     Resources(Vec<ComputeResource>),
+    PostData,
 }
 
 impl WorkDone {

--- a/machine_interface/src/function_driver/system_driver.rs
+++ b/machine_interface/src/function_driver/system_driver.rs
@@ -3,6 +3,15 @@ use crate::function_driver::SystemFunction;
 #[cfg(feature = "reqwest_io")]
 pub mod reqwest;
 
+#[cfg(feature = "reqwest_io")]
+pub mod http;
+
+#[cfg(feature = "reqwest_io")]
+pub mod distributed;
+
+#[cfg(feature = "reqwest_io")]
+pub mod context_util;
+
 /// HTTP function currently expects one set with requests formated by HTTP standard (in text).
 /// This means one line with the reqest method, a space, request url, another space and the protocol version
 /// ex.: "PUT /images/logo.png HTTP/1.1"
@@ -20,22 +29,30 @@ const HTTP_INPUT_SETS: [&str; 1] = ["request"];
 /// Additionally there is a set that only contains the bodies with the same item names as the requests.
 const HTTP_OUTPUT_SETS: [&str; 2] = ["response", "body"];
 
+const SEND_INPUT_SETS: [&str; 2] = ["send_meta", "send_data"];
+
+const SEND_OUTPUT_SETS: [&str; 0] = [];
+
+const RECV_INPUT_SETS: [&str; 1] = ["recv_meta"];
+
+const RECV_OUTPUT_SETS: [&str; 1] = ["recv_data"];
+
 /// Provides the input set names for a given system function
 pub fn get_system_function_input_sets(function: SystemFunction) -> Vec<String> {
     return match function {
-        SystemFunction::HTTP => HTTP_INPUT_SETS,
+        SystemFunction::HTTP => HTTP_INPUT_SETS.iter().map(|&name| name.to_string()).collect(),
+        SystemFunction::SEND => SEND_INPUT_SETS.iter().map(|&name| name.to_string()).collect(),
+        SystemFunction::RECV => RECV_INPUT_SETS.iter().map(|&name| name.to_string()).collect()
     }
-    .map(|name| name.to_string())
-    .to_vec();
 }
 
 /// Provies the output set names for a given system function
 pub fn get_system_function_output_sets(function: SystemFunction) -> Vec<String> {
     return match function {
-        SystemFunction::HTTP => &HTTP_OUTPUT_SETS,
+        SystemFunction::HTTP => HTTP_OUTPUT_SETS.iter().map(|&name| name.to_string()).collect(),
+        SystemFunction::SEND => SEND_OUTPUT_SETS.iter().map(|&name| name.to_string()).collect(),
+        SystemFunction::RECV => RECV_OUTPUT_SETS.iter().map(|&name| name.to_string()).collect()
     }
-    .map(|name| name.to_string())
-    .to_vec();
 }
 
 #[cfg(test)]

--- a/machine_interface/src/function_driver/system_driver/context_util.rs
+++ b/machine_interface/src/function_driver/system_driver/context_util.rs
@@ -1,0 +1,36 @@
+use dandelion_commons::{DandelionError, DandelionResult};
+
+use crate::{memory_domain::{Context, ContextTrait}, DataSet, DataItem};
+
+pub fn get_dataset_by_ident(context: &Context, ident: String) -> DandelionResult<&DataSet> {
+    return match context.content.iter().find(|set_option| {
+        if let Some(set) = set_option {
+            return set.ident == ident;
+        } else {
+            return false;
+        }
+    }) {
+        Some(Some(set)) => Ok(set),
+        _ => {
+            Err(DandelionError::MalformedSystemFuncArg(format!("No dataset {ident}")))
+        }
+    };
+}
+
+pub fn get_dataitem_by_ident(dataset: &DataSet, ident: String) -> DandelionResult<&DataItem> {
+    return match dataset.buffers.iter().find(|dataitem| {
+        return dataitem.ident == ident;
+    }) {
+        Some(dataitem) => Ok(dataitem),
+        _ => {
+            Err(DandelionError::MalformedSystemFuncArg(format!("No dataitem {ident}")))
+        }
+    };
+}
+
+pub fn read_dataitem_content(context: &Context, dataitem: &DataItem) -> DandelionResult<Vec<u8>> {
+    let mut request_buffer = Vec::with_capacity(dataitem.data.size);
+    request_buffer.resize(dataitem.data.size, 0);
+    context.read(dataitem.data.offset, &mut request_buffer)?;
+    return Ok(request_buffer);
+}

--- a/machine_interface/src/function_driver/system_driver/distributed.rs
+++ b/machine_interface/src/function_driver/system_driver/distributed.rs
@@ -1,0 +1,248 @@
+use dandelion_commons::{
+    records::{RecordPoint, Recorder}, 
+    DandelionResult, DandelionError
+};
+use serde::{Serialize, Deserialize};
+use crate::{function_driver::WorkDone, memory_domain::{Context, ContextTrait}, promise::Debt, DataSet};
+use reqwest::Client;
+use super::context_util::{get_dataset_by_ident, get_dataitem_by_ident, read_dataitem_content};
+use std::{collections::{btree_map::Entry::{Occupied, Vacant}, BTreeMap}, sync::Arc};
+use tokio::sync::{mpsc::{self, Sender}, Mutex};
+
+pub enum IntermediateData {
+    Ready(Arc<(DataSet, Vec<u8>)>),
+    Pending(Arc<Sender<(DataSet, Vec<u8>)>>)
+}
+
+pub struct IntermediateDataPool {
+    pool: Mutex<BTreeMap<String, IntermediateData>>,
+}
+
+// TODO: consider this carefully
+impl IntermediateDataPool {
+    pub fn new() -> Self {
+        Self {
+            pool: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    pub async fn post(&self, id: String, content: DataSet, binary: Vec<u8>) -> DandelionResult<()> {
+        let mut pool = self.pool.lock().await;
+        match pool.entry(id.clone()) {
+            Occupied(entry) => {
+                match entry.remove() {
+                    IntermediateData::Pending(sender) => {
+                        match sender.send((content, binary)).await {
+                            Ok(_) => {
+                                return Ok(())
+                            }
+                            Err(_) => {
+                                return Err(DandelionError::PostDataError(format!("{id} channel send error")));
+                            }
+                        }
+                    }
+                    IntermediateData::Ready(..) => {
+                        return Err(DandelionError::PostDataError(format!("{id} already in pool")));
+                    }
+                }
+
+            }
+            Vacant(entry) => {
+                entry.insert(IntermediateData::Ready(Arc::new((content, binary))));
+                return Ok(())
+            }
+        }
+    }
+
+    pub async fn subscribe(&self, id: String) -> DandelionResult<(DataSet, Vec<u8>)> {
+        let (sender, mut receiver) = mpsc::channel(1);
+        {
+            let mut pool = self.pool.lock().await;
+            match pool.entry(id.clone()) {
+                Occupied(entry) => {
+                    match entry.remove() {
+                        IntermediateData::Pending(_) => {
+                            return Err(DandelionError::PostDataError(format!("{id} already subscribed in pool")));
+                        }
+                        IntermediateData::Ready(data_arc) => {
+                            match Arc::try_unwrap(data_arc) {
+                                Ok(data) => {
+                                    return Ok(data);
+                                }
+                                Err(_) => {
+                                    return Err(DandelionError::PostDataError(format!("{id} cannot unwrap data")));
+                                }
+                            }
+                        }
+                    }
+                }
+                Vacant(entry) => {
+                    entry.insert(IntermediateData::Pending(Arc::new(sender)));
+                }
+            }
+        }
+        match receiver.recv().await {
+            Some(data) => {
+                return Ok(data);
+            }
+            None => {
+                return Err(DandelionError::PostDataError(format!("{id} channel recv error")));
+            }
+        }
+    }
+
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct DandelionSendInformation {
+    addr: String,
+    pub id: String,
+    pub content: DataSet,
+    pub binary: Vec<u8>
+}
+
+fn dandelion_send_setup(context: &Context) -> DandelionResult<DandelionSendInformation> {
+    let send_meta_set = get_dataset_by_ident(context, String::from("send_meta"))?;
+    let addr_item = get_dataitem_by_ident(send_meta_set, String::from("addr"))?;
+    let addr = match String::from_utf8(read_dataitem_content(context, addr_item)?) {
+        Ok(addr) => Ok(addr),
+        Err(_) => Err(DandelionError::MalformedSystemFuncArg(String::from("send: dandelion addr not valid"))),
+    }?;
+    let id_item = get_dataitem_by_ident(send_meta_set, String::from("id"))?;
+    let id = match String::from_utf8(read_dataitem_content(context, id_item)?) {
+        Ok(addr) => Ok(addr),
+        Err(_) => Err(DandelionError::MalformedSystemFuncArg(String::from("send: dandelion id not valid"))),
+    }?;
+    let send_data_set = get_dataset_by_ident(context, String::from("send_data"))?;
+    let mut content = send_data_set.clone(); // TODO: check if it's deep clone
+    let mut binary: Vec<u8> = vec![];
+    let mut offset = 0;
+    content.buffers.iter_mut().try_for_each(|item| {
+        let mut data = read_dataitem_content(context, item)?;
+        binary.append(&mut data);
+        item.data.offset = offset;
+        offset += item.data.size;
+        Ok(())
+    })?;
+    return Ok(DandelionSendInformation {
+        addr,
+        id,
+        content,
+        binary
+    });
+}
+
+async fn dandelion_send_request(
+    client: Client, 
+    send_info: DandelionSendInformation
+) -> DandelionResult<()> {
+    let addr = &send_info.addr;
+    if !client
+        .post(format!("{addr}/post_data"))
+        .body(bson::to_vec(&send_info).unwrap())
+        .send()
+        .await
+        .unwrap()
+        .status()
+        .is_success() {
+            return Err(DandelionError::PostDataError(format!("post dataset {} http error", send_info.content.ident)));
+        } else {
+            return Ok(())
+        }
+}
+
+pub async fn dandelion_send(
+    mut context: Context,
+    client: Client,
+    debt: Debt,
+    mut recorder: Recorder,
+) -> () {
+    if let Err(err) = recorder.record(RecordPoint::EngineStart) {
+        debt.fulfill(Box::new(Err(err)));
+        return;
+    }
+    let send_info = match dandelion_send_setup(&context) {
+        Ok(request) => request,
+        Err(err) => {
+            debt.fulfill(Box::new(Err(err)));
+            return;
+        }
+    };
+    match dandelion_send_request(client, send_info).await {
+        Ok(_) => (),
+        Err(err) => {
+            debt.fulfill(Box::new(Err(err)));
+            return;
+        }
+    };
+    context.clear_metadata();
+    if let Err(err) = recorder.record(RecordPoint::EngineEnd) {
+        debt.fulfill(Box::new(Err(err)));
+        return;
+    }
+    let results = Box::new(Ok(WorkDone::Context(context)));
+    debt.fulfill(results);
+    return;
+}
+
+async fn dandelion_recv_response(context: &Context, data_pool: Arc<IntermediateDataPool>) -> DandelionResult<(DataSet, Vec<u8>)> {
+    let recv_meta_set = get_dataset_by_ident(context, String::from("recv_meta"))?;
+    let id_item = get_dataitem_by_ident(recv_meta_set, String::from("id"))?;
+    let id = match String::from_utf8(read_dataitem_content(context, id_item)?) {
+        Ok(addr) => Ok(addr),
+        Err(_) => Err(DandelionError::MalformedSystemFuncArg(String::from("recv: dandelion id not valid"))),
+    }?;
+    return data_pool.subscribe(id).await;
+}
+
+fn dandelion_recv_context(context: &mut Context, mut content: DataSet, binary: Vec<u8>) -> DandelionResult<()> {
+    let base_offset = context.get_free_space(binary.len(), 128)?;
+    content.buffers.iter_mut().for_each(|item| {
+        item.data.offset += base_offset;
+    });
+    if let Some(response_set) = &mut context.content[0] {
+        response_set.buffers = content.buffers;
+    }
+    context.write(base_offset, &binary)?;
+    return Ok(());
+}
+
+pub async fn dandelion_recv(
+    mut context: Context,
+    output_set_names: Arc<Vec<String>>,
+    data_pool: Arc<IntermediateDataPool>,
+    debt: Debt,
+    mut recorder: Recorder,
+) -> () {
+    if let Err(err) = recorder.record(RecordPoint::EngineStart) {
+        debt.fulfill(Box::new(Err(err)));
+        return;
+    }
+    let (content, binary) = match dandelion_recv_response(&context, data_pool.clone()).await {
+        Ok((content, binary)) => (content, binary),
+        Err(err) => {
+            debt.fulfill(Box::new(Err(err)));
+            return;
+        }
+    };
+    context.clear_metadata();
+    if !output_set_names.is_empty() {
+        context.content = vec![None];
+        if output_set_names.iter().any(|elem| elem == "recv_data") {
+            context.content[0] = Some(DataSet {
+                ident: String::from("recv_data"),
+                buffers: vec![],
+            })
+        }
+        if let Err(err) = dandelion_recv_context(&mut context, content, binary) {
+            debt.fulfill(Box::new(Err(err)));
+            return;
+        }
+    }
+    if let Err(err) = recorder.record(RecordPoint::EngineEnd) {
+        debt.fulfill(Box::new(Err(err)));
+        return;
+    }
+    let results = Box::new(Ok(WorkDone::Context(context)));
+    debt.fulfill(results);
+}

--- a/machine_interface/src/function_driver/system_driver/http.rs
+++ b/machine_interface/src/function_driver/system_driver/http.rs
@@ -1,0 +1,374 @@
+use http::{version::Version, HeaderName, HeaderValue, Method};
+use reqwest::{header::HeaderMap, Client};
+use dandelion_commons::{
+    records::{RecordPoint, Recorder},
+    DandelionError, DandelionResult,
+};
+use crate::{
+    function_driver::WorkDone,
+    memory_domain::{Context, ContextTrait},
+    promise::Debt,
+    DataItem, DataSet, Position,
+};
+use bytes::Buf;
+use std::sync::Arc;
+use log::error;
+use super::context_util::{get_dataset_by_ident, read_dataitem_content};
+
+struct RequestInformation {
+    /// name of the request item
+    item_name: String,
+    /// key of the request item
+    item_key: u32,
+    method: Method,
+    uri: String,
+    version: Version,
+    headermap: HeaderMap,
+    body: Vec<u8>,
+}
+struct ResponseInformation {
+    /// name of the original request data item
+    item_name: String,
+    // key of the original request data item
+    item_key: u32,
+    /// contains both the status line as well as all headers
+    preamble: String,
+    body: bytes::Bytes,
+}
+
+fn convert_to_request(
+    mut raw_request: Vec<u8>,
+    item_name: String,
+    item_key: u32,
+) -> DandelionResult<RequestInformation> {
+    // read first line to get request line
+    let request_index = raw_request
+        .iter()
+        .position(|character| *character == b'\n')
+        .unwrap_or(raw_request.len());
+    let request_line = match std::str::from_utf8(&raw_request[0..request_index]) {
+        Ok(line) => line,
+        Err(_) => {
+            return Err(DandelionError::InvalidSystemFuncArg(String::from(
+                "Request line not utf8",
+            )));
+        }
+    };
+    let mut request_iter = request_line.split_ascii_whitespace();
+
+    let method_item = request_iter.next();
+    let method = match method_item {
+        Some(method_string) if method_string == "GET" => Method::GET,
+        Some(method_string) if method_string == "POST" => Method::POST,
+        Some(method_string) => {
+            return Err(DandelionError::InvalidSystemFuncArg(format!(
+                "Unsupported Method: {}",
+                method_string
+            )))
+        }
+        _ => {
+            return Err(DandelionError::MalformedSystemFuncArg(String::from(
+                "No method found",
+            )))
+        }
+    };
+
+    let uri = String::from(
+        request_iter
+            .next()
+            .ok_or(DandelionError::MalformedSystemFuncArg(String::from(
+                "No uri in request",
+            )))?,
+    );
+
+    let version = match request_iter.next() {
+        Some(version_string) if version_string == "HTTP/0.9" => Version::HTTP_09,
+        Some(version_string) if version_string == "HTTP/1.0" => Version::HTTP_10,
+        Some(version_string) if version_string == "HTTP/1.1" => Version::HTTP_11,
+        Some(version_string) if version_string == "HTTP/2.0" => Version::HTTP_2,
+        Some(version_string) if version_string == "HTTP/3.0" => Version::HTTP_3,
+        Some(version_string) => {
+            return Err(DandelionError::InvalidSystemFuncArg(format!(
+                "unkown http version: {}",
+                version_string,
+            )))
+        }
+        None => {
+            return Err(DandelionError::MalformedSystemFuncArg(String::from(
+                "No http version found",
+            )))
+        }
+    };
+
+    // read new lines until end of header map
+    let mut header_index = request_index + 1;
+    let mut headermap = HeaderMap::new();
+    while header_index < raw_request.len() {
+        let header_line = raw_request[header_index..]
+            .iter()
+            .position(|character| *character == b'\n')
+            .and_then(|header_end| Some(&raw_request[header_index..header_index + header_end]))
+            .unwrap_or(&raw_request[header_index..]);
+        // skip the \n at the index itself
+        header_index += header_line.len() + 1;
+        // if the header line is empty there are two consequtive new lines which means the headers are finished
+        // or the request is at the end which also means there are not more lines to read
+        if header_line.len() == 0 {
+            break;
+        }
+        let split_index = header_line
+            .iter()
+            .position(|character| *character == b':')
+            .ok_or(DandelionError::MalformedSystemFuncArg(String::from(
+                "Header line does not contain \':\'",
+            )))?;
+        let (key, value) = header_line.split_at(split_index);
+        let header_key = HeaderName::from_bytes(key).or(Err(
+            DandelionError::MalformedSystemFuncArg(String::from("Header key not utf-8")),
+        ))?;
+        let header_value = HeaderValue::from_bytes(&value[1..]).or(Err(
+            DandelionError::MalformedSystemFuncArg(String::from(
+                "Header value not utf-8 conformant",
+            )),
+        ))?;
+        match headermap.entry(header_key) {
+            http::header::Entry::Occupied(mut occupied) => occupied.append(header_value),
+            http::header::Entry::Vacant(vacant) => {
+                vacant.insert(header_value);
+            }
+        }
+    }
+    let body = if header_index < raw_request.len() {
+        raw_request.drain(..header_index);
+        raw_request
+    } else {
+        vec![]
+    };
+    log::trace!("Reqwest body: {:?}", body);
+
+    return Ok(RequestInformation {
+        item_name,
+        item_key,
+        method,
+        uri,
+        version,
+        headermap,
+        body,
+    });
+}
+
+fn http_setup(context: &Context) -> DandelionResult<Vec<RequestInformation>> {
+    let request_set = get_dataset_by_ident(context, String::from("request"))?;
+    let request_info: DandelionResult<Vec<RequestInformation>> = request_set
+        .buffers
+        .iter()
+        .map(|set_item| {
+            let request_buffer = read_dataitem_content(context, set_item)?;
+            convert_to_request(request_buffer, set_item.ident.clone(), set_item.key)
+        })
+        .collect();
+    return request_info;
+}
+
+async fn http_request(
+    client: Client,
+    request_info: RequestInformation,
+) -> DandelionResult<ResponseInformation> {
+    let RequestInformation {
+        item_name,
+        item_key,
+        method,
+        uri,
+        version,
+        headermap,
+        body,
+    } = request_info;
+
+    let request_builder = match method {
+        Method::PUT => client.put(uri.clone()),
+        Method::POST => client.post(uri.clone()),
+        Method::GET => client.get(uri.clone()),
+        _ => {
+            return Err(DandelionError::MalformedSystemFuncArg(String::from(
+                "Unsupported Method",
+            )))
+        }
+    };
+
+    let request = match request_builder
+        .headers(headermap)
+        .version(version)
+        .body(body)
+        .build()
+    {
+        Ok(req) => req,
+        Err(http_error) => {
+            error!("URI: {}", uri);
+            return Err(DandelionError::MalformedSystemFuncArg(format!(
+                "{:?}",
+                http_error
+            )));
+        }
+    };
+    let response = match client.execute(request).await {
+        Ok(resp) => resp,
+        Err(_) => return Err(DandelionError::SystemFuncResponseError),
+    };
+
+    // write the status line
+    let mut preamble = format!(
+        "{:?} {} {}\n",
+        response.version(),
+        response.status().as_str(),
+        response.status().canonical_reason().unwrap_or("")
+    );
+
+    // read the content length in the header
+    // TODO also accept chunked data
+    let content_length = response
+        .headers()
+        .get("content-length")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|len_str| len_str.parse::<usize>().ok())
+        .ok_or(DandelionError::SystemFuncResponseError)?;
+
+    for (key, value) in response.headers() {
+        preamble.push_str(&format!("{}:{}\n", key, value.to_str().unwrap()));
+    }
+
+    preamble.push('\n');
+
+    let body = match response.bytes().await {
+        Ok(bytes) => bytes,
+        Err(_) => return Err(DandelionError::SystemFuncResponseError),
+    };
+
+    if content_length == body.len() {
+        let response_info = ResponseInformation {
+            item_name,
+            item_key,
+            preamble,
+            body,
+        };
+        return Ok(response_info);
+    } else {
+        return Err(DandelionError::SystemFuncResponseError);
+    }
+}
+
+fn http_context_write(context: &mut Context, response: ResponseInformation) -> DandelionResult<()> {
+    let ResponseInformation {
+        item_name,
+        item_key,
+        preamble,
+        mut body,
+    } = response;
+
+    // allocate space in the context for the entire response
+    let preable_len = preamble.len();
+    let body_len = body.len();
+    let response_len = preable_len + body_len;
+    let response_start = context.get_free_space(response_len, 128)?;
+    context.write(response_start, preamble.as_bytes())?;
+    let mut bytes_read = 0;
+    while bytes_read < body_len {
+        let chunk = body.chunk();
+        let reading = chunk.len();
+        context.write(response_start + preable_len + bytes_read, chunk)?;
+        body.advance(reading);
+        bytes_read += reading;
+    }
+    assert_eq!(
+        0,
+        body.remaining(),
+        "Body should have non remaining as we have read the amount given as len in the beginning"
+    );
+    if let Some(response_set) = &mut context.content[0] {
+        response_set.buffers.push(DataItem {
+            ident: item_name.clone(),
+            key: item_key,
+            data: Position {
+                offset: response_start,
+                size: response_len,
+            },
+        })
+    }
+    if let Some(body_set) = &mut context.content[1] {
+        body_set.buffers.push(DataItem {
+            ident: item_name,
+            key: item_key,
+            data: Position {
+                offset: response_start + preable_len,
+                size: response_len - preable_len,
+            },
+        })
+    }
+
+    return Ok(());
+}
+
+pub async fn http_run(
+    mut context: Context,
+    client: Client,
+    output_set_names: Arc<Vec<String>>,
+    debt: Debt,
+    mut recorder: Recorder,
+) -> () {
+    if let Err(err) = recorder.record(RecordPoint::EngineStart) {
+        debt.fulfill(Box::new(Err(err)));
+        return;
+    }
+    let request_vec = match http_setup(&context) {
+        Ok(request) => request,
+        Err(err) => {
+            debt.fulfill(Box::new(Err(err)));
+            return;
+        }
+    };
+    let response_vec = match futures::future::try_join_all(
+        request_vec
+            .into_iter()
+            .map(|request| http_request(client.clone(), request)),
+    )
+    .await
+    {
+        Ok(resp) => resp,
+        Err(err) => {
+            debt.fulfill(Box::new(Err(err)));
+            return;
+        }
+    };
+
+    // only clear once for all requests
+    context.clear_metadata();
+    if !output_set_names.is_empty() {
+        context.content = vec![None, None];
+        if output_set_names.iter().any(|elem| elem == "response") {
+            context.content[0] = Some(DataSet {
+                ident: String::from("response"),
+                buffers: vec![],
+            })
+        }
+        if output_set_names.iter().any(|elem| elem == "body") {
+            context.content[1] = Some(DataSet {
+                ident: String::from("body"),
+                buffers: vec![],
+            })
+        }
+        let write_results: DandelionResult<Vec<_>> = response_vec
+            .into_iter()
+            .map(|response| http_context_write(&mut context, response))
+            .collect();
+        if let Err(err) = write_results {
+            debt.fulfill(Box::new(Err(err)));
+            return;
+        }
+    }
+    if let Err(err) = recorder.record(RecordPoint::EngineEnd) {
+        debt.fulfill(Box::new(Err(err)));
+        return;
+    }
+    let results = Box::new(Ok(WorkDone::Context(context)));
+    debt.fulfill(results);
+    return;
+}

--- a/machine_interface/src/function_driver/system_driver/reqwest.rs
+++ b/machine_interface/src/function_driver/system_driver/reqwest.rs
@@ -1,395 +1,24 @@
 use crate::{
     function_driver::{
-        ComputeResource, Driver, Function, FunctionConfig, SystemFunction, WorkDone, WorkQueue,
-        WorkToDo,
+        ComputeResource, Driver, Function, FunctionConfig, ReqwestWorkToDo, SystemFunction, WorkDone, WorkQueue, WorkToDo
     },
-    memory_domain::{self, Context, ContextTrait},
     promise::Debt,
-    DataItem, DataSet, Position,
 };
-use bytes::Buf;
 use core_affinity::set_for_current;
 use dandelion_commons::{
-    records::{RecordPoint, Recorder},
+    records::RecordPoint,
     DandelionError, DandelionResult,
 };
 use futures::StreamExt;
-use http::{version::Version, HeaderName, HeaderValue, Method};
-use log::error;
-use reqwest::{header::HeaderMap, Client};
-use std::sync::Arc;
 use tokio::runtime::Builder;
+use core::str::FromStr;
+use std::sync::Arc;
+use reqwest::Client;
+use super::{distributed::IntermediateDataPool, http::http_run};
+use super::distributed::{dandelion_send, dandelion_recv};
+use crate::memory_domain;
 
-struct RequestInformation {
-    /// name of the request item
-    item_name: String,
-    /// key of the request item
-    item_key: u32,
-    method: Method,
-    uri: String,
-    version: Version,
-    headermap: HeaderMap,
-    body: Vec<u8>,
-}
-struct ResponseInformation {
-    /// name of the original request data item
-    item_name: String,
-    // key of the original request data item
-    item_key: u32,
-    /// contains both the status line as well as all headers
-    preamble: String,
-    body: bytes::Bytes,
-}
-
-fn convert_to_request(
-    mut raw_request: Vec<u8>,
-    item_name: String,
-    item_key: u32,
-) -> DandelionResult<RequestInformation> {
-    // read first line to get request line
-    let request_index = raw_request
-        .iter()
-        .position(|character| *character == b'\n')
-        .unwrap_or(raw_request.len());
-    let request_line = match std::str::from_utf8(&raw_request[0..request_index]) {
-        Ok(line) => line,
-        Err(_) => {
-            return Err(DandelionError::InvalidSystemFuncArg(String::from(
-                "Request line not utf8",
-            )));
-        }
-    };
-    let mut request_iter = request_line.split_ascii_whitespace();
-
-    let method_item = request_iter.next();
-    let method = match method_item {
-        Some(method_string) if method_string == "GET" => Method::GET,
-        Some(method_string) if method_string == "POST" => Method::POST,
-        Some(method_string) => {
-            return Err(DandelionError::InvalidSystemFuncArg(format!(
-                "Unsupported Method: {}",
-                method_string
-            )))
-        }
-        _ => {
-            return Err(DandelionError::MalformedSystemFuncArg(String::from(
-                "No method found",
-            )))
-        }
-    };
-
-    let uri = String::from(
-        request_iter
-            .next()
-            .ok_or(DandelionError::MalformedSystemFuncArg(String::from(
-                "No uri in request",
-            )))?,
-    );
-
-    let version = match request_iter.next() {
-        Some(version_string) if version_string == "HTTP/0.9" => Version::HTTP_09,
-        Some(version_string) if version_string == "HTTP/1.0" => Version::HTTP_10,
-        Some(version_string) if version_string == "HTTP/1.1" => Version::HTTP_11,
-        Some(version_string) if version_string == "HTTP/2.0" => Version::HTTP_2,
-        Some(version_string) if version_string == "HTTP/3.0" => Version::HTTP_3,
-        Some(version_string) => {
-            return Err(DandelionError::InvalidSystemFuncArg(format!(
-                "unkown http version: {}",
-                version_string,
-            )))
-        }
-        None => {
-            return Err(DandelionError::MalformedSystemFuncArg(String::from(
-                "No http version found",
-            )))
-        }
-    };
-
-    // read new lines until end of header map
-    let mut header_index = request_index + 1;
-    let mut headermap = HeaderMap::new();
-    while header_index < raw_request.len() {
-        let header_line = raw_request[header_index..]
-            .iter()
-            .position(|character| *character == b'\n')
-            .and_then(|header_end| Some(&raw_request[header_index..header_index + header_end]))
-            .unwrap_or(&raw_request[header_index..]);
-        // skip the \n at the index itself
-        header_index += header_line.len() + 1;
-        // if the header line is empty there are two consequtive new lines which means the headers are finished
-        // or the request is at the end which also means there are not more lines to read
-        if header_line.len() == 0 {
-            break;
-        }
-        let split_index = header_line
-            .iter()
-            .position(|character| *character == b':')
-            .ok_or(DandelionError::MalformedSystemFuncArg(String::from(
-                "Header line does not contain \':\'",
-            )))?;
-        let (key, value) = header_line.split_at(split_index);
-        let header_key = HeaderName::from_bytes(key).or(Err(
-            DandelionError::MalformedSystemFuncArg(String::from("Header key not utf-8")),
-        ))?;
-        let header_value = HeaderValue::from_bytes(&value[1..]).or(Err(
-            DandelionError::MalformedSystemFuncArg(String::from(
-                "Header value not utf-8 conformant",
-            )),
-        ))?;
-        match headermap.entry(header_key) {
-            http::header::Entry::Occupied(mut occupied) => occupied.append(header_value),
-            http::header::Entry::Vacant(vacant) => {
-                vacant.insert(header_value);
-            }
-        }
-    }
-    let body = if header_index < raw_request.len() {
-        raw_request.drain(..header_index);
-        raw_request
-    } else {
-        vec![]
-    };
-    log::trace!("Reqwest body: {:?}", body);
-
-    return Ok(RequestInformation {
-        item_name,
-        item_key,
-        method,
-        uri,
-        version,
-        headermap,
-        body,
-    });
-}
-
-fn http_setup(context: &Context) -> DandelionResult<Vec<RequestInformation>> {
-    let request_set = match context.content.iter().find(|set_option| {
-        if let Some(set) = set_option {
-            return set.ident == "request";
-        } else {
-            return false;
-        }
-    }) {
-        Some(Some(set)) => set,
-        _ => {
-            return Err(DandelionError::MalformedSystemFuncArg(String::from(
-                "No request set",
-            )))
-        }
-    };
-    let request_info: DandelionResult<Vec<RequestInformation>> = request_set
-        .buffers
-        .iter()
-        .map(|set_item| {
-            let mut request_buffer = Vec::with_capacity(set_item.data.size);
-            request_buffer.resize(set_item.data.size, 0);
-            context.read(set_item.data.offset, &mut request_buffer)?;
-            convert_to_request(request_buffer, set_item.ident.clone(), set_item.key)
-        })
-        .collect();
-    return request_info;
-}
-
-async fn http_request(
-    client: Client,
-    request_info: RequestInformation,
-) -> DandelionResult<ResponseInformation> {
-    let RequestInformation {
-        item_name,
-        item_key,
-        method,
-        uri,
-        version,
-        headermap,
-        body,
-    } = request_info;
-
-    let request_builder = match method {
-        Method::PUT => client.put(uri.clone()),
-        Method::POST => client.post(uri.clone()),
-        Method::GET => client.get(uri.clone()),
-        _ => {
-            return Err(DandelionError::MalformedSystemFuncArg(String::from(
-                "Unsupported Method",
-            )))
-        }
-    };
-
-    let request = match request_builder
-        .headers(headermap)
-        .version(version)
-        .body(body)
-        .build()
-    {
-        Ok(req) => req,
-        Err(http_error) => {
-            error!("URI: {}", uri);
-            return Err(DandelionError::MalformedSystemFuncArg(format!(
-                "{:?}",
-                http_error
-            )));
-        }
-    };
-    let response = match client.execute(request).await {
-        Ok(resp) => resp,
-        Err(_) => return Err(DandelionError::SystemFuncResponseError),
-    };
-
-    // write the status line
-    let mut preamble = format!(
-        "{:?} {} {}\n",
-        response.version(),
-        response.status().as_str(),
-        response.status().canonical_reason().unwrap_or("")
-    );
-
-    // read the content length in the header
-    // TODO also accept chunked data
-    let content_length = response
-        .headers()
-        .get("content-length")
-        .and_then(|value| value.to_str().ok())
-        .and_then(|len_str| len_str.parse::<usize>().ok())
-        .ok_or(DandelionError::SystemFuncResponseError)?;
-
-    for (key, value) in response.headers() {
-        preamble.push_str(&format!("{}:{}\n", key, value.to_str().unwrap()));
-    }
-
-    preamble.push('\n');
-
-    let body = match response.bytes().await {
-        Ok(bytes) => bytes,
-        Err(_) => return Err(DandelionError::SystemFuncResponseError),
-    };
-
-    if content_length == body.len() {
-        let response_info = ResponseInformation {
-            item_name,
-            item_key,
-            preamble,
-            body,
-        };
-        return Ok(response_info);
-    } else {
-        return Err(DandelionError::SystemFuncResponseError);
-    }
-}
-
-fn http_context_write(context: &mut Context, response: ResponseInformation) -> DandelionResult<()> {
-    let ResponseInformation {
-        item_name,
-        item_key,
-        preamble,
-        mut body,
-    } = response;
-
-    // allocate space in the context for the entire response
-    let preable_len = preamble.len();
-    let body_len = body.len();
-    let response_len = preable_len + body_len;
-    let response_start = context.get_free_space(response_len, 128)?;
-    context.write(response_start, preamble.as_bytes())?;
-    let mut bytes_read = 0;
-    while bytes_read < body_len {
-        let chunk = body.chunk();
-        let reading = chunk.len();
-        context.write(response_start + preable_len + bytes_read, chunk)?;
-        body.advance(reading);
-        bytes_read += reading;
-    }
-    assert_eq!(
-        0,
-        body.remaining(),
-        "Body should have non remaining as we have read the amount given as len in the beginning"
-    );
-    if let Some(response_set) = &mut context.content[0] {
-        response_set.buffers.push(DataItem {
-            ident: item_name.clone(),
-            key: item_key,
-            data: Position {
-                offset: response_start,
-                size: response_len,
-            },
-        })
-    }
-    if let Some(body_set) = &mut context.content[1] {
-        body_set.buffers.push(DataItem {
-            ident: item_name,
-            key: item_key,
-            data: Position {
-                offset: response_start + preable_len,
-                size: response_len - preable_len,
-            },
-        })
-    }
-
-    return Ok(());
-}
-
-async fn http_run(
-    mut context: Context,
-    client: Client,
-    output_set_names: Arc<Vec<String>>,
-    debt: Debt,
-    mut recorder: Recorder,
-) -> () {
-    let request_vec = match http_setup(&context) {
-        Ok(request) => request,
-        Err(err) => {
-            debt.fulfill(Box::new(Err(err)));
-            return;
-        }
-    };
-    let response_vec = match futures::future::try_join_all(
-        request_vec
-            .into_iter()
-            .map(|request| http_request(client.clone(), request)),
-    )
-    .await
-    {
-        Ok(resp) => resp,
-        Err(err) => {
-            debt.fulfill(Box::new(Err(err)));
-            return;
-        }
-    };
-
-    // only clear once for all requests
-    context.clear_metadata();
-    if !output_set_names.is_empty() {
-        context.content = vec![None, None];
-        if output_set_names.iter().any(|elem| elem == "response") {
-            context.content[0] = Some(DataSet {
-                ident: String::from("response"),
-                buffers: vec![],
-            })
-        }
-        if output_set_names.iter().any(|elem| elem == "body") {
-            context.content[1] = Some(DataSet {
-                ident: String::from("body"),
-                buffers: vec![],
-            })
-        }
-        let write_results: DandelionResult<Vec<_>> = response_vec
-            .into_iter()
-            .map(|response| http_context_write(&mut context, response))
-            .collect();
-        if let Err(err) = write_results {
-            debt.fulfill(Box::new(Err(err)));
-            return;
-        }
-    }
-    if let Err(err) = recorder.record(RecordPoint::EngineEnd) {
-        debt.fulfill(Box::new(Err(err)));
-        return;
-    }
-    let results = Box::new(Ok(WorkDone::Context(context)));
-    debt.fulfill(results);
-    return;
-}
-
-async fn engine_loop(queue: Box<dyn WorkQueue + Send>) -> Debt {
+async fn engine_loop(queue: Box<dyn WorkQueue + Send>, data_pool: Arc<IntermediateDataPool>) -> Debt {
     log::debug!("Reqwest engine Init");
     let client = Client::new();
     // TODO FIX! This should not be necessary!
@@ -407,12 +36,8 @@ async fn engine_loop(queue: Box<dyn WorkQueue + Send>) -> Debt {
                 config,
                 context,
                 output_sets,
-                mut recorder,
+                recorder,
             } => {
-                if let Err(err) = recorder.record(RecordPoint::EngineStart) {
-                    debt.fulfill(Box::new(Err(err)));
-                    continue;
-                }
                 // let result = engine_state.run(config, context, output_sets);
                 log::debug!("Reqwest engine running function");
                 let function = match config {
@@ -428,6 +53,23 @@ async fn engine_loop(queue: Box<dyn WorkQueue + Send>) -> Debt {
                             context,
                             client.clone(),
                             output_sets,
+                            debt,
+                            recorder,
+                        ));
+                    }
+                    SystemFunction::SEND => {
+                        tokio::spawn(dandelion_send(
+                            context,
+                            client.clone(),
+                            debt,
+                            recorder,
+                        ));
+                    }
+                    SystemFunction::RECV => {
+                        tokio::spawn(dandelion_recv(
+                            context,
+                            output_sets,
+                            data_pool.clone(),
                             debt,
                             recorder,
                         ));
@@ -493,6 +135,27 @@ async fn engine_loop(queue: Box<dyn WorkQueue + Send>) -> Debt {
                 }
                 continue;
             }
+            WorkToDo::Reqwest { 
+                work,
+                mut recorder,
+            } => {
+                match work {
+                    ReqwestWorkToDo::PostData {
+                        id,
+                        content,
+                        binary,
+                    } => {
+                        recorder.record(RecordPoint::PostDataStart).unwrap();
+                        let post_data_result = data_pool.post(id, content, binary).await;
+                        recorder.record(RecordPoint::PostDataEnd).unwrap();
+                        match post_data_result {
+                            Ok(_) => debt.fulfill(Box::new(Ok(WorkDone::PostData))),
+                            Err(err) => debt.fulfill(Box::new(Err(err))),
+                        }
+                        continue;
+                    }
+                }
+            }
             WorkToDo::Shutdown() => {
                 return debt;
             }
@@ -500,7 +163,7 @@ async fn engine_loop(queue: Box<dyn WorkQueue + Send>) -> Debt {
     }
 }
 
-fn outer_engine(core_id: u8, queue: Box<dyn WorkQueue + Send>) {
+fn outer_engine(core_id: u8, queue: Box<dyn WorkQueue + Send>, data_pool: Arc<IntermediateDataPool>) {
     // set core affinity
     if !core_affinity::set_for_current(core_affinity::CoreId { id: core_id.into() }) {
         log::error!("core received core id that could not be set");
@@ -517,14 +180,24 @@ fn outer_engine(core_id: u8, queue: Box<dyn WorkQueue + Send>) {
         .build()
         .or(Err(DandelionError::EngineError))
         .unwrap();
-    let debt = runtime.block_on(engine_loop(queue));
+    let debt = runtime.block_on(engine_loop(queue, data_pool.clone()));
     drop(runtime);
     debt.fulfill(Box::new(Ok(WorkDone::Resources(vec![
         ComputeResource::CPU(core_id),
     ]))));
 }
 
-pub struct ReqwestDriver {}
+pub struct ReqwestDriver {
+    data_pool: Arc<IntermediateDataPool>
+}
+
+impl ReqwestDriver {
+    pub fn new() -> Self {
+        Self {
+            data_pool: Arc::new(IntermediateDataPool::new())
+        }
+    }
+}
 
 impl Driver for ReqwestDriver {
     fn start_engine(
@@ -549,7 +222,8 @@ impl Driver for ReqwestDriver {
         {
             return Err(DandelionError::EngineResourceError);
         }
-        std::thread::spawn(move || outer_engine(core_id, queue));
+        let data_pool = self.data_pool.clone();
+        std::thread::spawn(move || outer_engine(core_id, queue, data_pool.clone()));
         return Ok(());
     }
 
@@ -561,13 +235,14 @@ impl Driver for ReqwestDriver {
         if function_path.len() != 0 {
             return Err(DandelionError::CalledSystemFuncParser);
         }
+        let system_function = SystemFunction::from_str(&function_path).unwrap();
         return Ok(Function {
             requirements: crate::DataRequirementList {
                 input_requirements: vec![],
                 static_requirements: vec![],
             },
             context: static_domain.acquire_context(0)?,
-            config: FunctionConfig::SysConfig(SystemFunction::HTTP),
+            config: FunctionConfig::SysConfig(system_function),
         });
     }
 }

--- a/machine_interface/src/function_driver/system_driver/reqwest.rs
+++ b/machine_interface/src/function_driver/system_driver/reqwest.rs
@@ -1,6 +1,6 @@
 use crate::{
     function_driver::{
-        ComputeResource, Driver, Function, FunctionConfig, ReqwestWorkToDo, SystemFunction, WorkDone, WorkQueue, WorkToDo
+        ComputeResource, Driver, Function, FunctionConfig, ReqwestWork, SystemFunction, WorkDone, WorkQueue, WorkToDo
     },
     promise::Debt,
 };
@@ -232,7 +232,7 @@ impl Driver for ReqwestDriver {
         function_path: String,
         static_domain: &'static dyn crate::memory_domain::MemoryDomain,
     ) -> DandelionResult<Function> {
-        if function_path.len() != 0 {
+        if function_path.len() == 0 {
             return Err(DandelionError::CalledSystemFuncParser);
         }
         let system_function = SystemFunction::from_str(&function_path).unwrap();

--- a/machine_interface/src/function_driver/thread_utils.rs
+++ b/machine_interface/src/function_driver/thread_utils.rs
@@ -3,7 +3,7 @@ use crate::{
     memory_domain::{self, Context},
 };
 use core::marker::Send;
-use dandelion_commons::{records::RecordPoint, DandelionResult};
+use dandelion_commons::{records::RecordPoint, DandelionError, DandelionResult};
 use std::thread::spawn;
 
 extern crate alloc;
@@ -108,6 +108,9 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn WorkQueue>) {
                     ComputeResource::CPU(core_id),
                 ]))));
                 return;
+            }
+            _ => {
+                debt.fulfill(Box::new(Err(DandelionError::InvalidWorkToDo)));
             }
         }
     }

--- a/machine_interface/src/lib.rs
+++ b/machine_interface/src/lib.rs
@@ -44,13 +44,13 @@ pub struct Position {
     pub size: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataSet {
     pub ident: String,
     pub buffers: Vec<DataItem>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataItem {
     pub ident: String,
     pub data: Position,

--- a/machine_interface/src/machine_config.rs
+++ b/machine_interface/src/machine_config.rs
@@ -50,7 +50,11 @@ const SYS_FUNC_DEFAULT_CONTEXT_SIZE: usize = 0x200_0000;
 pub fn get_system_functions(engine_type: EngineType) -> Vec<(SystemFunction, usize)> {
     return match engine_type {
         #[cfg(feature = "reqwest_io")]
-        EngineType::Reqwest => vec![(SystemFunction::HTTP, SYS_FUNC_DEFAULT_CONTEXT_SIZE)],
+        EngineType::Reqwest => vec![
+            (SystemFunction::HTTP, SYS_FUNC_DEFAULT_CONTEXT_SIZE),
+            (SystemFunction::SEND, SYS_FUNC_DEFAULT_CONTEXT_SIZE),
+            (SystemFunction::RECV, SYS_FUNC_DEFAULT_CONTEXT_SIZE)
+        ],
         #[allow(unreachable_patterns)]
         _ => Vec::new(),
     };
@@ -94,7 +98,7 @@ pub fn get_available_drivers() -> BTreeMap<EngineType, &'static dyn Driver> {
         (
             EngineType::Reqwest,
             Box::leak(Box::new(
-                crate::function_driver::system_driver::reqwest::ReqwestDriver {},
+                crate::function_driver::system_driver::reqwest::ReqwestDriver::new(),
             )) as &'static dyn Driver,
         ),
         #[cfg(feature = "cheri")]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -26,6 +26,7 @@ signal-hook = "0.3.17"
 signal-hook-tokio = {version = "0.3.1", features = [ "futures-v0_3"]}
 # input parsing
 clap = {version = "4.5", features = ["env","derive"]}
+bincode = "1.3.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -298,8 +298,11 @@ async fn post_data(
         .await
         .expect("failed to extract body from post data")
         .to_bytes();
-    let send_info: DandelionSendInformation = 
-        bson::from_slice(&bytes).expect("should be able to deserialize send info");
+    // TODO: the following code should use BytesContext::from_bytes_vec to construct context, but should extract id first
+    let meta_binary_len: usize = bincode::deserialize(&bytes[..8]).unwrap();
+    let mut send_info: DandelionSendInformation = 
+        bson::from_slice(&bytes[8..8+meta_binary_len]).expect("should be able to deserialize send info");
+    send_info.binary = bytes[8+meta_binary_len..].to_vec();
     let (callback, confirmation) = oneshot::channel();
     dispatcher
         .send(DispatcherCommand::PostData {


### PR DESCRIPTION
This is the initial implementation of SEND and RECV system function to support distributed execution of composition. 

### Design

The SEND function takes two inputs: ***send_meta*** and ***send_data***. The ***send_meta*** dataset includes two key dataitems: ***addr***, representing the destination address in the format of `ip:port`, and ***id***, a unique data identifier generated by the upper-level cluster scheduler (e.g., Dirigent). The ***send_data*** dataset contains the actual data you wish to transmit to another host. The SEND function does not return any dataset.

The RECV function takes a single input dataset: ***recv_meta***, which includes the ***id*** as the dataset identifier. The RECV function outputs a dataset: ***recv_data***, which contains the data corresponding to the received dataset.

In operation, the SEND function constructs an HTTP request to transmit the ***send_data*** dataset. Upon receiving the dataset, the destination host stores it in an intermediate data pool, indexed by the ***id***. The RECV function subscribes to this data pool and retrieves the dataset as soon as it becomes available.

### Example

Here is an example of matmul function pair, the original and the distributed composition description. 

```
SINGLE_NODE:
(:function matmul (in_data) -> (out_data))
(:composition comp_matmul (comp_in) -> (comp_out) (
	(matmul ((in_data <- comp_in)) => ((comp_intermediate := out_data)))
	(matmul ((in_data <- comp_intermediate)) => ((comp_out := out_data)))
))
```

```
DISTRIBUTED:
SENDER:
(:function matmul (in_data) -> (out_data))
(:function SEND (send_meta send_data) -> ())
(:composition comp_matmul_1 (comp_in comp_send_meta) -> () (
	(matmul ((in_data <- comp_in)) => ((comp_intermediate := out_data)))
	(SEND ((send_meta <- comp_send_meta) (send_data <- comp_intermediate)) => ())
))
RECEIVER:
(:function matmul (in_data) -> (out_data))
(:function RECV (recv_meta) -> (recv_data))
(:composition comp_matmul_2 (comp_recv_meta) -> (comp_out) (
	(RECV ((recv_meta <- comp_recv_meta)) => ((comp_intermediate := recv_data)))
	(matmul ((in_data <- comp_intermediate)) => ((comp_out := out_data)))
))
```

### Todo
1. Implement the SEND and RECV functions using existing (de)serialization methods, such as dandelion_server::DandelionBody::new and BytesContext::from_bytes_vec. This will require restructuring crates and mods.
2. Enhance the SEND and RECV functions to support dataset sharding (e.g. dataset partitioned by key). The current implementation processes the dataset as a single unit.