### PR TITLE
Add local path to registration

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -646,7 +646,10 @@ fn main() -> () {
     runtime.block_on(service_loop(dispatcher_sender, config.port));
 
     // clean up folder in tmp that is used for function storage
-    std::fs::remove_dir_all(FUNCTION_FOLDER_PATH).unwrap();
+    let removal_error = std::fs::remove_dir_all(FUNCTION_FOLDER_PATH);
+    if let Err(err) = removal_error {
+        warn!("Removing function folder failed with: {}", err);
+    }
     // clean up folder with shared files in case the context backed by shared files left some behind
     for shm_dir_entry in std::fs::read_dir("/dev/shm/").unwrap() {
         if let Ok(shm_file) = shm_dir_entry {

--- a/server/tests/server_tests.rs
+++ b/server/tests/server_tests.rs
@@ -298,6 +298,7 @@ mod server_tests {
         let status = status_result.unwrap();
         assert_eq!(status, None, "Server exited unexpectedly");
     }
+
     #[test]
     #[serial]
     fn serve_matmul_http_1_1() {


### PR DESCRIPTION
Allow registering also with local path instead of binary to safe time on transferring binaries which are already present on the worker node.