### PR TITLE
Add Circuit Breaking and Retrying policy in the proxy runtime

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -39,6 +39,9 @@ const DEFAULT_NGHTTP2_CODEC_BIN_LOCAL_PATH: &str = "./nghttp2_codec3";
 const DEFAULT_AUTHORIZATION_POLICY_NAME: &str = "authorization_policy";
 const DEFAULT_JWT_POLICY_NAME: &str = "jwt_policy";
 
+const DEFAULT_MAX_TCP_CONNECTIONS: usize = 100;
+const DEFAULT_MAX_HTTP2_PENDING_REQUSTS: usize = 100;
+
 #[derive(serde::Deserialize, Parser, Debug)]
 pub struct DandelionConfig {
     #[arg(long, env, default_value_t = String::from(DEFAULT_CONFIG_PATH))]
@@ -99,6 +102,10 @@ pub struct DandelionConfig {
     #[arg(long, env, default_value_t = String::from(DEFAULT_PROXY_TLS_MATERIAL_DIR))]
     #[serde(default)]
     pub proxy_tls_material_dir: String,
+    #[arg(long, env, default_value_t = DEFAULT_MAX_TCP_CONNECTIONS)]
+    pub max_tcp_connections: usize,
+    #[arg(long, env, default_value_t = DEFAULT_MAX_HTTP2_PENDING_REQUSTS)]
+    pub max_http2_pending_requests: usize,
 }
 
 impl DandelionConfig {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -45,6 +45,9 @@ const DEFAULT_CONSECUTIVE_5XX_ERRORS: usize = 3;
 const DEFAULT_OUTLIER_CHECK_INTERVAL: u64 = 1; // second
 const DEFAULT_BASE_EJECTION_TIME: u64 = 10; // second
 
+const DEFAULT_MAX_RETRY_TIMES: usize = 3;
+const DEFAULT_PER_RETRY_TIMEOUT: u64 = 2; // second
+
 #[derive(serde::Deserialize, Parser, Debug)]
 pub struct DandelionConfig {
     #[arg(long, env, default_value_t = String::from(DEFAULT_CONFIG_PATH))]
@@ -115,6 +118,10 @@ pub struct DandelionConfig {
     pub outlier_check_interval: u64,
     #[arg(long, env, default_value_t = DEFAULT_BASE_EJECTION_TIME)]
     pub base_ejection_time: u64,
+    #[arg(long, env, default_value_t = DEFAULT_MAX_RETRY_TIMES)]
+    pub max_retry_times: usize,
+    #[arg(long, env, default_value_t = DEFAULT_PER_RETRY_TIMEOUT)]
+    pub per_retry_timeout: u64,
 }
 
 impl DandelionConfig {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -41,6 +41,9 @@ const DEFAULT_JWT_POLICY_NAME: &str = "jwt_policy";
 
 const DEFAULT_MAX_TCP_CONNECTIONS: usize = 100;
 const DEFAULT_MAX_HTTP2_PENDING_REQUSTS: usize = 100;
+const DEFAULT_CONSECUTIVE_5XX_ERRORS: usize = 3;
+const DEFAULT_OUTLIER_CHECK_INTERVAL: u64 = 1; // second
+const DEFAULT_BASE_EJECTION_TIME: u64 = 10; // second
 
 #[derive(serde::Deserialize, Parser, Debug)]
 pub struct DandelionConfig {
@@ -106,6 +109,12 @@ pub struct DandelionConfig {
     pub max_tcp_connections: usize,
     #[arg(long, env, default_value_t = DEFAULT_MAX_HTTP2_PENDING_REQUSTS)]
     pub max_http2_pending_requests: usize,
+    #[arg(long, env, default_value_t = DEFAULT_CONSECUTIVE_5XX_ERRORS)]
+    pub consecutive_5xx_errors: usize,
+    #[arg(long, env, default_value_t = DEFAULT_OUTLIER_CHECK_INTERVAL)]
+    pub outlier_check_interval: u64,
+    #[arg(long, env, default_value_t = DEFAULT_BASE_EJECTION_TIME)]
+    pub base_ejection_time: u64,
 }
 
 impl DandelionConfig {

--- a/server/src/dirigent_proxy.rs
+++ b/server/src/dirigent_proxy.rs
@@ -1173,6 +1173,12 @@ impl Default for StreamWorkerToDpConnReq {
     }
 }
 
+struct FuncConnTuple {
+    conn_id: u32, // used to distinguish connections to the same sandbox
+    func_conn_worker: mpsc::Sender<StreamWorkerToFuncConnReq>,
+    num_pending_reqs: usize,
+}
+
 // a helper func used by the worker to read from a tcp stream until blocking
 async fn read_from_tcp_stream_until_blocking(
     stream: &mut TcpStream,
@@ -1556,9 +1562,8 @@ async fn router(
     request_sender: mpsc::Sender<DispatcherCommand>,
     mut stream_worker_to_router_rx: mpsc::Receiver<StreamWorkerToRouterReq>,
 ) {
-    // ***TMP and TO DO***: currently we assume that for each user container/url, there will only be one connection
-    // key: url; value: the channel to the func_conn_worker, which handles the connection to that func container
-    let mut uc_connections: HashMap<String, mpsc::Sender<StreamWorkerToFuncConnReq>> =
+    // key: url; value: connection pool
+    let mut uc_connections2: HashMap<String, (u32, u32, Vec<FuncConnTuple>)> = 
         HashMap::new();
 
     // Process requests from stream workers
@@ -1582,21 +1587,46 @@ async fn router(
 
         // *** Check if there is a need to create a new connection ***
         let mut need_to_create_a_new_connection: bool = false;
-        if uc_connections.contains_key(&destination_url_string) {
-            if uc_connections
-                .get(&destination_url_string)
-                .unwrap()
-                .is_closed()
-            {
-                info!("[Router] The connection stored in the map is closed. Need to create a new connection to the uc");
+        let mut selected_conn_idx: usize = 0;
+        if uc_connections2.contains_key(&destination_url_string) {
+
+            let (num_consecutive_errors, _, vec_func_conn_tuple) = uc_connections2
+                .get_mut(&destination_url_string)
+                .unwrap();
+
+            let mut i = 0;
+
+            while i < vec_func_conn_tuple.len() {
+                // if the conn is already closed, remove it
+                if vec_func_conn_tuple[i].func_conn_worker.is_closed() {
+                    debug!("[Router] The func connection is already closed. Remove it from the pool");
+                    vec_func_conn_tuple.remove(i);
+                    continue;
+                }
+
+                // Check the num of pending reqs on ths conn
+                if vec_func_conn_tuple[i].num_pending_reqs < 50 {
+                    selected_conn_idx = i;
+                    break;
+                }
+
+                i += 1;
+            }
+
+            // all connections in the pool has a max num of pending reqs
+            if i >= vec_func_conn_tuple.len() {
                 need_to_create_a_new_connection = true;
-                uc_connections.remove(&destination_url_string);
             }
         } else {
             need_to_create_a_new_connection = true;
+            uc_connections2.insert(destination_url_string.clone(), (0, 0, Vec::new()));
         }
 
         if need_to_create_a_new_connection == true {
+            let (_, new_conn_id, vec_func_conn_tuple) = uc_connections2
+                .get_mut(&destination_url_string)
+                .unwrap();
+
             (
                 stream_worker_to_func_connection_worker_tx,
                 stream_worker_to_func_connection_worker_rx,
@@ -1617,10 +1647,12 @@ async fn router(
                         stream_worker_to_func_connection_worker_rx,
                     ));
 
-                    uc_connections.insert(
-                        destination_url_string,
-                        stream_worker_to_func_connection_worker_tx.clone(),
-                    );
+                    vec_func_conn_tuple.push(FuncConnTuple {
+                        conn_id: *new_conn_id,
+                        func_conn_worker: stream_worker_to_func_connection_worker_tx.clone(),
+                        num_pending_reqs: 0,
+                    });
+                    *new_conn_id = *new_conn_id + 1;
                 }
                 Err(e) => {
                     error!(
@@ -1629,13 +1661,19 @@ async fn router(
                     );
                 }
             }
-        } else {
+        } 
+        else {
             debug!(
                 "[Router] already has a connection to {}",
                 destination_url_string
             );
-            stream_worker_to_func_connection_worker_tx =
-                uc_connections.get(&destination_url_string).unwrap().clone();
+
+            let (_, _, vec_func_conn_tuple) = uc_connections2
+                .get_mut(&destination_url_string)
+                .unwrap();
+
+            stream_worker_to_func_connection_worker_tx = 
+                vec_func_conn_tuple[selected_conn_idx].func_conn_worker.clone();
         }
 
         // Send the answer to the stream worker

--- a/server/src/dirigent_proxy.rs
+++ b/server/src/dirigent_proxy.rs
@@ -1173,9 +1173,14 @@ impl Default for StreamWorkerToDpConnReq {
     }
 }
 
+struct RouterToFuncConnReq {
+    function_connection_worker_to_router_tx: oneshot::Sender<usize>,
+}
+
 struct FuncConnTuple {
     conn_id: u32, // used to distinguish connections to the same sandbox
-    func_conn_worker: mpsc::Sender<StreamWorkerToFuncConnReq>,
+    stream_worker_to_func_connection_worker_tx: mpsc::Sender<StreamWorkerToFuncConnReq>,
+    router_to_func_connection_worker_tx: mpsc::Sender<RouterToFuncConnReq>,
     num_pending_reqs: usize,
 }
 
@@ -1259,6 +1264,7 @@ async fn func_connection_worker3(
     mut stream: TcpStream,
     request_sender: mpsc::Sender<DispatcherCommand>,
     mut stream_worker_to_func_connection_worker_rx: mpsc::Receiver<StreamWorkerToFuncConnReq>,
+    mut router_to_func_connection_worker_rx: mpsc::Receiver<RouterToFuncConnReq>
 ) {
     let tcp_conn_local_addr = stream.local_addr().unwrap();
     let tcp_conn_peer_addr = stream.peer_addr().unwrap();
@@ -1272,6 +1278,9 @@ async fn func_connection_worker3(
     // Value: Channel to the stream worker (to send the corresponding response)
     let mut stream_worker_map: HashMap<i32, oneshot::Sender<FunctionConnToStreamWorkerResp>> =
         HashMap::new();
+
+    // Some numbers to track
+    let mut num_pending_reqs: usize = 0;
 
     // Output (set_0) from the nghttp2 codec (other sets 1~n use local vars; each set is for one req or resp)
     let mut session_state: Vec<u8> = vec![0u8; 20 * 1024]; // Also the input
@@ -1417,6 +1426,12 @@ async fn func_connection_worker3(
                         channel_to_send_back_resp_list.push(Some(req.function_connection_worker_to_stream_worker_tx));
                     }
                 }
+                Some(req) = router_to_func_connection_worker_rx.recv() => { // 3) Req from the router to know the num of pending requests
+                    let _ = req.function_connection_worker_to_router_tx.send(num_pending_reqs);
+                    continue;
+                }
+
+
             }
         }
 
@@ -1478,6 +1493,9 @@ async fn func_connection_worker3(
         size_of_session_state = session_state.len();
 
         // ****** Operations triggered by output set 0 *******
+        num_pending_reqs = num_pending_reqs + num_of_req_or_resp_sent - num_of_req_or_res_received;
+        debug!("[func_connection_worker3. Local Addr: {}; Peer Addr: {}] num_pending_reqs {}", tcp_conn_local_addr, tcp_conn_peer_addr, num_pending_reqs);
+
         let mut stream_id_list_sent_requests_i32: Vec<i32> = Vec::new();
         for i in 0..num_of_req_or_resp_sent {
             // let arr: [u8; size_of::<usize>()]  =
@@ -1598,14 +1616,43 @@ async fn router(
 
             while i < vec_func_conn_tuple.len() {
                 // if the conn is already closed, remove it
-                if vec_func_conn_tuple[i].func_conn_worker.is_closed() {
-                    debug!("[Router] The func connection is already closed. Remove it from the pool");
+                if vec_func_conn_tuple[i].stream_worker_to_func_connection_worker_tx.is_closed() {
+                    info!("[Router] The func connection(url: {}, conn_id: {}) is already closed. Remove it from the pool", destination_url_string, vec_func_conn_tuple[i].conn_id);
                     vec_func_conn_tuple.remove(i);
                     continue;
                 }
 
                 // Check the num of pending reqs on ths conn
-                if vec_func_conn_tuple[i].num_pending_reqs < 50 {
+                let (func_conn_worker_to_router_tx, func_conn_worker_to_router_rx) =
+                    oneshot::channel::<usize>();
+
+                let _  = vec_func_conn_tuple[i].router_to_func_connection_worker_tx.send(
+                    RouterToFuncConnReq {
+                        function_connection_worker_to_router_tx: func_conn_worker_to_router_tx
+                    }
+                ).await;
+
+                match func_conn_worker_to_router_rx.await {
+                    Ok(num) => {
+                        vec_func_conn_tuple[i].num_pending_reqs = num;
+                        debug!(
+                            "[Router] gets the numbder of pending requests on func conn (url: {}, conn_id: {}): {}",
+                            destination_url_string, 
+                            vec_func_conn_tuple[i].conn_id,
+                            vec_func_conn_tuple[i].num_pending_reqs
+                        );  
+                    }
+                    Err(e) => {
+                        error!(
+                            "[Router] fails to get the num of pending requests on func conn (url: {}, conn_id: {}) with error: {}",
+                            destination_url_string, 
+                            vec_func_conn_tuple[i].conn_id,
+                            e
+                        );                           
+                    }
+                }
+
+                if vec_func_conn_tuple[i].num_pending_reqs < 50 { // we pick this conn if the num of pending requests is less than the threshold
                     selected_conn_idx = i;
                     break;
                 }
@@ -1632,6 +1679,11 @@ async fn router(
                 stream_worker_to_func_connection_worker_rx,
             ) = mpsc::channel::<StreamWorkerToFuncConnReq>(32);
 
+            let (
+                router_to_func_connection_worker_tx,
+                router_to_func_connection_worker_rx,
+            ) = mpsc::channel::<RouterToFuncConnReq>(32);
+
             match TcpStream::connect(&destination_url_string).await {
                 Ok(s) => {
                     info!(
@@ -1645,11 +1697,13 @@ async fn router(
                         stream,
                         request_sender.clone(),
                         stream_worker_to_func_connection_worker_rx,
+                        router_to_func_connection_worker_rx,
                     ));
 
                     vec_func_conn_tuple.push(FuncConnTuple {
                         conn_id: *new_conn_id,
-                        func_conn_worker: stream_worker_to_func_connection_worker_tx.clone(),
+                        stream_worker_to_func_connection_worker_tx: stream_worker_to_func_connection_worker_tx.clone(),
+                        router_to_func_connection_worker_tx: router_to_func_connection_worker_tx.clone(),
                         num_pending_reqs: 0,
                     });
                     *new_conn_id = *new_conn_id + 1;
@@ -1673,7 +1727,7 @@ async fn router(
                 .unwrap();
 
             stream_worker_to_func_connection_worker_tx = 
-                vec_func_conn_tuple[selected_conn_idx].func_conn_worker.clone();
+                vec_func_conn_tuple[selected_conn_idx].stream_worker_to_func_connection_worker_tx.clone();
         }
 
         // Send the answer to the stream worker

--- a/server/src/dirigent_proxy.rs
+++ b/server/src/dirigent_proxy.rs
@@ -1127,6 +1127,9 @@ struct StreamWorkerToRouterReq {
 struct RouterToStreamWorkerResp {
     payload: String,
     stream_worker_to_func_connection_worker_tx: mpsc::Sender<StreamWorkerToFuncConnReq>,
+    circuit_break: bool,
+    cb_response_status: String,
+    cb_response_body: String,
 }
 
 struct FunctionConnToStreamWorkerResp {
@@ -1257,6 +1260,32 @@ async fn read_from_stream_until_blocking<S:ProxyStream>(
         }
     }
 }
+
+fn generate_circuit_break_resp (
+    cb_resp_status: String,
+    cb_resp_body: String,
+) -> (Vec<u8>, Vec<u8>) {
+    let mut headers: Vec<u8> = Vec::new();
+    let mut body_to_send: Vec<u8> = Vec::new();
+
+    let header_status_name_string = ":status\0";
+    let header_stauts_name_len = header_status_name_string.len();
+    let header_stauts_name_len_bytes = header_stauts_name_len.to_ne_bytes();
+    let header_status_value_string = cb_resp_status;
+    let header_stauts_value_len = header_status_value_string.len();
+    let header_stauts_value_len_bytes = header_stauts_value_len.to_ne_bytes();
+    headers.extend_from_slice(&header_stauts_name_len_bytes);
+    headers.extend_from_slice(header_status_name_string.as_bytes());
+    headers.extend_from_slice(&header_stauts_value_len_bytes);
+    headers.extend_from_slice(header_status_value_string.as_bytes());
+
+    let body_to_send_string = cb_resp_body;          
+    body_to_send.extend_from_slice(body_to_send_string.as_bytes());
+
+    return (headers, body_to_send);
+
+}
+
 // This handles the TCP/HTTP connection with user function container
 // Thus, it acts as a HTTP client
 async fn func_connection_worker3(
@@ -1580,6 +1609,11 @@ async fn router(
     request_sender: mpsc::Sender<DispatcherCommand>,
     mut stream_worker_to_router_rx: mpsc::Receiver<StreamWorkerToRouterReq>,
 ) {
+    let config = dandelion_server::config::DandelionConfig::get_config();
+    let max_tcp_connections = config.max_tcp_connections;
+    let max_http2_pending_requests = config.max_http2_pending_requests;
+    info!("[Router] max_tcp_connections: {}, max_http2_pending_requests: {}", max_tcp_connections, max_http2_pending_requests);
+
     // key: url; value: connection pool
     let mut uc_connections2: HashMap<String, (u32, u32, Vec<FuncConnTuple>)> = 
         HashMap::new();
@@ -1605,6 +1639,9 @@ async fn router(
 
         // *** Check if there is a need to create a new connection ***
         let mut need_to_create_a_new_connection: bool = false;
+        let mut circuit_break: bool = false;
+        let mut circuit_break_resp_status: String = String::from("");
+        let mut circuit_break_resp_body: String = String::from("");
         let mut selected_conn_idx: usize = 0;
         if uc_connections2.contains_key(&destination_url_string) {
 
@@ -1614,6 +1651,7 @@ async fn router(
 
             let mut i = 0;
 
+            // Iterate through the current connection pool
             while i < vec_func_conn_tuple.len() {
                 // if the conn is already closed, remove it
                 if vec_func_conn_tuple[i].stream_worker_to_func_connection_worker_tx.is_closed() {
@@ -1652,7 +1690,7 @@ async fn router(
                     }
                 }
 
-                if vec_func_conn_tuple[i].num_pending_reqs < 50 { // we pick this conn if the num of pending requests is less than the threshold
+                if vec_func_conn_tuple[i].num_pending_reqs < max_http2_pending_requests { // we pick this conn if the num of pending requests is less than the threshold
                     selected_conn_idx = i;
                     break;
                 }
@@ -1663,6 +1701,17 @@ async fn router(
             // all connections in the pool has a max num of pending reqs
             if i >= vec_func_conn_tuple.len() {
                 need_to_create_a_new_connection = true;
+            }
+
+            // Check if we have already achieved the max num of connections
+            if need_to_create_a_new_connection == true && vec_func_conn_tuple.len() >= max_tcp_connections {
+                info!("[Router] circuit breaking (url: {}), exceed max num of pending requests and connections", 
+                    destination_url_string, 
+                );
+                need_to_create_a_new_connection = false;
+                circuit_break = true;
+                circuit_break_resp_status = String::from("503\0");
+                circuit_break_resp_body = String::from("Service Unavailable: exceed max num of pending requests and connections");
             }
         } else {
             need_to_create_a_new_connection = true;
@@ -1735,6 +1784,9 @@ async fn router(
             payload: format!("router processed the request: {}", req.payload),
             stream_worker_to_func_connection_worker_tx: stream_worker_to_func_connection_worker_tx
                 .clone(),
+            circuit_break: circuit_break,
+            cb_response_status: circuit_break_resp_status,
+            cb_response_body: circuit_break_resp_body,
         };
         let _ = req
             .router_to_stream_worker_tx
@@ -1942,6 +1994,26 @@ async fn stream_worker(
     match router_to_stream_worker_rx.await {
         Ok(resp) => {
             debug!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] gets resp from the router", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id);
+
+            // From the router, we know if there is a circuit breaking
+            if resp.circuit_break == true { // If there is, directly return a error response
+                    let (cb_resp_headers, cb_resp_body) = generate_circuit_break_resp(resp.cb_response_status, resp.cb_response_body);
+                    let _ = stream_worker_to_dp_connection_worker_tx
+                        .send(StreamWorkerToDpConnReq {
+                            payload: format!(
+                                "[stream worker:{}] circuit breaking",
+                                stream_id,
+                            ),
+                            stream_id_to_send_response: stream_id,
+                            num_of_headers_to_send: 1,
+                            trailer_offset: -1,
+                            num_of_trailers_to_send: 0,                        
+                            headers: cb_resp_headers,
+                            body_to_send: cb_resp_body,
+                        })
+                        .await;
+                    return;
+            }
 
             // From the router, we now know which user-func connection to use
             let stream_worker_to_func_connection_worker_tx =

--- a/server/src/dirigent_proxy.rs
+++ b/server/src/dirigent_proxy.rs
@@ -1178,7 +1178,7 @@ struct StreamWorkerToFuncConnReq {
     num_of_trailers_to_send: usize,
     headers: Vec<u8>,
     body: Vec<u8>,
-    function_connection_worker_to_stream_worker_tx: oneshot::Sender<FunctionConnToStreamWorkerResp>,
+    function_connection_worker_to_stream_worker_tx: mpsc::Sender<FunctionConnToStreamWorkerResp>,
 }
 
 struct StreamWorkerToDpConnReq {
@@ -1290,7 +1290,7 @@ async fn read_from_stream_until_blocking<S:ProxyStream>(
     }
 }
 
-fn generate_circuit_break_resp (
+fn generate_circuit_break_retry_resp (
     cb_resp_status: String,
     cb_resp_body: String,
 ) -> (Vec<u8>, Vec<u8>) {
@@ -1334,7 +1334,7 @@ async fn func_connection_worker3(
     // Hash Map
     // Key: Stream id of the sent request
     // Value: Channel to the stream worker (to send the corresponding response)
-    let mut stream_worker_map: HashMap<i32, oneshot::Sender<FunctionConnToStreamWorkerResp>> =
+    let mut stream_worker_map: HashMap<i32, mpsc::Sender<FunctionConnToStreamWorkerResp>> =
         HashMap::new();
 
     // Some numbers to track
@@ -1394,7 +1394,7 @@ async fn func_connection_worker3(
         size_of_body_to_send_list = Vec::new();
 
         let mut channel_to_send_back_resp_list: Vec<
-            Option<oneshot::Sender<FunctionConnToStreamWorkerResp>>,
+            Option<mpsc::Sender<FunctionConnToStreamWorkerResp>>,
         > = Vec::new();
 
         // ****** If first create, we directly call the codec (as a client to initialize the connection) ******
@@ -1615,7 +1615,7 @@ async fn func_connection_worker3(
                 Some(c) => {
                     // debug!("[func conn worker] sends response to stream worker {}", stream_id);
 
-                    c.send(FunctionConnToStreamWorkerResp {
+                    let _ = c.send(FunctionConnToStreamWorkerResp {
                         payload: format!("get resp from user func"),
                         resp_status: resp_status,
                         num_of_headers_to_send: num_of_headers,
@@ -1623,7 +1623,7 @@ async fn func_connection_worker3(
                         num_of_trailers_to_send: num_of_trailers,
                         headers: headers_received,
                         body_to_send: body_received,
-                    });
+                    }).await;
                 }
                 None => {
                     error!("[func_connection_worker3. Local Addr: {}; Peer Addr: {}] There is no channel in the hasp map to send back resp to stream worker! The send request (to the uc) stream id: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id);
@@ -2035,6 +2035,11 @@ async fn stream_worker(
         tcp_conn_local_addr, tcp_conn_peer_addr, stream_id
     );
 
+    // config (retry)
+    let config = dandelion_server::config::DandelionConfig::get_config();
+    let max_retry_times = config.max_retry_times;
+    let per_retry_timeout = config.per_retry_timeout;
+
     let header_pairs: Vec<(String, String)> = match parse_headers(&headers_received) {
         Ok(v) => {
             // debug!("headers parsed: {:?}", v);
@@ -2113,158 +2118,220 @@ async fn stream_worker(
         }
     }
 
-    // The stream worker would query the router to get the channel to the user_func_conn_worker
-    // The channel used by the router to send resp back
-    let (router_to_stream_worker_tx, router_to_stream_worker_rx) =
-        oneshot::channel::<RouterToStreamWorkerResp>();
+    // If we receive sth from this channel, it's the time to retry
+    let mut current_retry_times: usize = 0;
+    let (time_to_retry_tx, mut time_to_retry_rx) = mpsc::channel::<usize>(32);
 
-    // ****** send request to the router ******
-    if let Err(e) = stream_worker_to_router_tx
-        .send(StreamWorkerToRouterReq {
-            payload: format!("request from stream worker: {}", stream_id),
-            header_authority_value_string: header_authority_value_string,
-            header_x_anakonda_forward_value_string: header_x_anakonda_forward_value_string.clone(),
-            router_to_stream_worker_tx: router_to_stream_worker_tx,
-        })
-        .await
-    {
-        error!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] failed to send to router: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, e);
+    // Used to get resp(s) back from the func_conn_worker
+    let (
+        function_connection_worker_to_stream_worker_tx,
+        mut function_connection_worker_to_stream_worker_rx,
+    ) = mpsc::channel::<FunctionConnToStreamWorkerResp>(32);
 
-        // If we fail to send req to the router
-        let _ = stream_worker_to_dp_connection_worker_tx
-            .send(StreamWorkerToDpConnReq {
-                payload: format!(
-                    "[stream worker:{}] failed to send to router: {}",
-                    stream_id, e
-                ),
-                ..Default::default()
+    // The retry loop
+    loop {
+        // The stream worker would query the router to get the channel to the user_func_conn_worker
+        // The channel used by the router to send resp back
+        let (router_to_stream_worker_tx, router_to_stream_worker_rx) =
+            oneshot::channel::<RouterToStreamWorkerResp>();
+
+        // ****** send request to the router ******
+        if let Err(e) = stream_worker_to_router_tx
+            .send(StreamWorkerToRouterReq {
+                payload: format!("request from stream worker: {}", stream_id),
+                header_authority_value_string: header_authority_value_string.clone(),
+                header_x_anakonda_forward_value_string: header_x_anakonda_forward_value_string.clone(),
+                router_to_stream_worker_tx: router_to_stream_worker_tx,
             })
-            .await;
-        return;
-    }
+            .await
+        {
+            error!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] failed to send to router: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, e);
 
-    // ****** Wait for router's resp ******
-    match router_to_stream_worker_rx.await {
-        Ok(resp) => {
-            debug!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] gets resp from the router", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id);
-
-            // From the router, we know if there is a circuit breaking
-            if resp.circuit_break == true { // If there is, directly return a error response
-                    let (cb_resp_headers, cb_resp_body) = generate_circuit_break_resp(resp.cb_response_status, resp.cb_response_body);
-                    let _ = stream_worker_to_dp_connection_worker_tx
-                        .send(StreamWorkerToDpConnReq {
-                            payload: format!(
-                                "[stream worker:{}] circuit breaking",
-                                stream_id,
-                            ),
-                            stream_id_to_send_response: stream_id,
-                            num_of_headers_to_send: 1,
-                            trailer_offset: -1,
-                            num_of_trailers_to_send: 0,                        
-                            headers: cb_resp_headers,
-                            body_to_send: cb_resp_body,
-                        })
-                        .await;
-                    return;
-            }
-
-            // From the router, we now know which user-func connection to use
-            let stream_worker_to_func_connection_worker_tx =
-                resp.stream_worker_to_func_connection_worker_tx;
-
-            // Used to get the resp back from the func_conn_worker
-            let (
-                function_connection_worker_to_stream_worker_tx,
-                function_connection_worker_to_stream_worker_rx,
-            ) = oneshot::channel::<FunctionConnToStreamWorkerResp>();
-            // send request to the func_conn worker
-            if let Err(e) = stream_worker_to_func_connection_worker_tx
-                .send(StreamWorkerToFuncConnReq {
-                    payload: format!("request from stream worker: {}", stream_id),
-                    stream_id: stream_id,
-                    num_of_headers_to_send: num_of_headers_received,
-                    trailer_offset: trailer_offset,
-                    num_of_trailers_to_send: num_of_trailers_received,
-                    headers: headers_received,
-                    body: body_received,
-                    function_connection_worker_to_stream_worker_tx:
-                        function_connection_worker_to_stream_worker_tx,
-                })
-                .await
-            {
-                error!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] failed to send to user func conn worker: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, e);
-
-                // If we fail to send to user func conn worker
-                let _ = stream_worker_to_dp_connection_worker_tx
-                    .send(StreamWorkerToDpConnReq {
-                        payload: format!(
-                            "[stream worker:{}] failed to send to user func conn worker: {}",
-                            stream_id, e
-                        ),
-                        ..Default::default()
-                    })
-                    .await;
-                return;
-            }
-
-            // *** Wait for the resp from the user func conn worker ***
-            match function_connection_worker_to_stream_worker_rx.await {
-                Ok(resp) => {
-                    info!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] gets resp from the user func conn worker with status {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, &resp.resp_status);
-
-                    // Check the resp status: is it a 5xx error?
-                    let resp_status_is_5xx = is_5xx(&resp.resp_status);
-
-                    if resp_status_is_5xx == true {
-                        let _ = stream_worker_to_router_report_5xx_error_tx
-                            .send(StreamWorkerToRouterReport5xxErrorReq { 
-                                header_x_anakonda_forward_value_string 
-                            })
-                            .await;
-                    }
-
-                    let _ = stream_worker_to_dp_connection_worker_tx
-                        .send(StreamWorkerToDpConnReq {
-                            payload: format!(
-                                "[stream worker:{}] final response: {} ",
-                                stream_id, resp.payload
-                            ),
-                            stream_id_to_send_response: stream_id,
-                            num_of_headers_to_send: resp.num_of_headers_to_send,
-                            trailer_offset: resp.trailer_offset,
-                            num_of_trailers_to_send: resp.num_of_trailers_to_send,
-                            headers: resp.headers,
-                            body_to_send: resp.body_to_send,
-                        })
-                        .await;
-                }
-                Err(e) => {
-                    error!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] fails to get resp from the func conn worker: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, e);
-
-                    let _ = stream_worker_to_dp_connection_worker_tx
-                        .send(
-                            StreamWorkerToDpConnReq {
-                                payload: format!("[stream worker:{}] fails to receive from the user func conn worker: {} ", stream_id, e),
-                                ..Default::default()
-                            }
-                        )
-                        .await;
-                }
-            }
-        }
-        Err(e) => {
-            error!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] failed to receive from the router: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, e);
-
+            // If we fail to send req to the router
             let _ = stream_worker_to_dp_connection_worker_tx
                 .send(StreamWorkerToDpConnReq {
                     payload: format!(
-                        "[stream worker:{}] failed to receive from router: {}",
+                        "[stream worker:{}] failed to send to router: {}",
                         stream_id, e
                     ),
                     ..Default::default()
                 })
                 .await;
+            return;
         }
+
+        // ****** Wait for router's resp ******
+        match router_to_stream_worker_rx.await {
+            Ok(resp) => {
+                debug!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] gets resp from the router", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id);
+
+                // From the router, we know if there is a circuit breaking
+                if resp.circuit_break == true { // If there is, directly return a error response
+                        let (cb_resp_headers, cb_resp_body) = generate_circuit_break_retry_resp(resp.cb_response_status, resp.cb_response_body);
+                        let _ = stream_worker_to_dp_connection_worker_tx
+                            .send(StreamWorkerToDpConnReq {
+                                payload: format!(
+                                    "[stream worker:{}] circuit breaking",
+                                    stream_id,
+                                ),
+                                stream_id_to_send_response: stream_id,
+                                num_of_headers_to_send: 1,
+                                trailer_offset: -1,
+                                num_of_trailers_to_send: 0,                        
+                                headers: cb_resp_headers,
+                                body_to_send: cb_resp_body,
+                            })
+                            .await;
+                        return;
+                }
+
+                // From the router, we now know which user-func connection to use
+                let stream_worker_to_func_connection_worker_tx =
+                    resp.stream_worker_to_func_connection_worker_tx;
+
+                // send request to the func_conn worker
+                if let Err(e) = stream_worker_to_func_connection_worker_tx
+                    .send(StreamWorkerToFuncConnReq {
+                        payload: format!("request from stream worker: {}", stream_id),
+                        stream_id: stream_id,
+                        num_of_headers_to_send: num_of_headers_received,
+                        trailer_offset: trailer_offset,
+                        num_of_trailers_to_send: num_of_trailers_received,
+                        headers: headers_received.clone(),
+                        body: body_received.clone(),
+                        function_connection_worker_to_stream_worker_tx:
+                            function_connection_worker_to_stream_worker_tx.clone(),
+                    })
+                    .await
+                {
+                    error!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] failed to send to user func conn worker: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, e);
+
+                    // If we fail to send to user func conn worker
+                    let _ = stream_worker_to_dp_connection_worker_tx
+                        .send(StreamWorkerToDpConnReq {
+                            payload: format!(
+                                "[stream worker:{}] failed to send to user func conn worker: {}",
+                                stream_id, e
+                            ),
+                            ..Default::default()
+                        })
+                        .await;
+                    return;
+                }
+
+                // Reset the retry timeout timer
+                let time_to_retry_tx_clone = time_to_retry_tx.clone();
+                tokio::spawn(async move {
+                    sleep(Duration::from_secs(per_retry_timeout)).await;
+                    let _ = time_to_retry_tx_clone.send(current_retry_times).await;
+                });
+
+                
+
+                // *** Wait for the resp from the user func conn worker ***
+                tokio::select! {
+                    Some(resp) = function_connection_worker_to_stream_worker_rx.recv() => { // 1) If we receive the resp from the function connection worker
+                        debug!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] gets resp from the user func conn worker with status {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, &resp.resp_status);
+
+                        // Check the resp status: is it a 5xx error?
+                        let resp_status_is_5xx = is_5xx(&resp.resp_status);
+
+                        if resp_status_is_5xx == true {
+                            // Report the 5xx error to the router
+                            let _ = stream_worker_to_router_report_5xx_error_tx
+                                .send(StreamWorkerToRouterReport5xxErrorReq { 
+                                    header_x_anakonda_forward_value_string: header_x_anakonda_forward_value_string.clone() 
+                                })
+                                .await;
+
+                            if current_retry_times < max_retry_times {
+                                current_retry_times = current_retry_times + 1;
+                                debug!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] retry because receives the 5xx error. Already retry times: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, current_retry_times);
+                                continue; // start the next loop
+                            }
+                            else { // return an error response
+                                let (cb_resp_headers, cb_resp_body) = generate_circuit_break_retry_resp(String::from("505\0"), String::from("Service Unavailable: Exceed Max Retry Times"));
+                                let _ = stream_worker_to_dp_connection_worker_tx
+                                    .send(StreamWorkerToDpConnReq {
+                                        payload: format!(
+                                            "[stream worker:{}] Exceed Max Retry Times",
+                                            stream_id,
+                                        ),
+                                        stream_id_to_send_response: stream_id,
+                                        num_of_headers_to_send: 1,
+                                        trailer_offset: -1,
+                                        num_of_trailers_to_send: 0,                        
+                                        headers: cb_resp_headers,
+                                        body_to_send: cb_resp_body,
+                                    })
+                                    .await;
+                                return;
+
+                            }
+                        }
+
+                        let _ = stream_worker_to_dp_connection_worker_tx
+                            .send(StreamWorkerToDpConnReq {
+                                payload: format!(
+                                    "[stream worker:{}] final response: {} ",
+                                    stream_id, resp.payload
+                                ),
+                                stream_id_to_send_response: stream_id,
+                                num_of_headers_to_send: resp.num_of_headers_to_send,
+                                trailer_offset: resp.trailer_offset,
+                                num_of_trailers_to_send: resp.num_of_trailers_to_send,
+                                headers: resp.headers,
+                                body_to_send: resp.body_to_send,
+                            })
+                            .await;
+                    }
+                    Some(n) = time_to_retry_rx.recv() => {
+                        let next_retry_times = n + 1;
+
+                        if current_retry_times < next_retry_times {
+                            if current_retry_times < max_retry_times {
+                                current_retry_times = current_retry_times + 1;
+                                debug!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] retry because of the timeout. Already retry times: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, current_retry_times);
+                                continue; // start the next loop
+                            }
+                            else { // return an error response
+                                let (cb_resp_headers, cb_resp_body) = generate_circuit_break_retry_resp(String::from("505\0"), String::from("Service Unavailable: Exceed Max Retry Times"));
+                                let _ = stream_worker_to_dp_connection_worker_tx
+                                    .send(StreamWorkerToDpConnReq {
+                                        payload: format!(
+                                            "[stream worker:{}] Exceed Max Retry Times",
+                                            stream_id,
+                                        ),
+                                        stream_id_to_send_response: stream_id,
+                                        num_of_headers_to_send: 1,
+                                        trailer_offset: -1,
+                                        num_of_trailers_to_send: 0,                        
+                                        headers: cb_resp_headers,
+                                        body_to_send: cb_resp_body,
+                                    })
+                                    .await;
+                                return;
+
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                error!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] failed to receive from the router: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, e);
+
+                let _ = stream_worker_to_dp_connection_worker_tx
+                    .send(StreamWorkerToDpConnReq {
+                        payload: format!(
+                            "[stream worker:{}] failed to receive from router: {}",
+                            stream_id, e
+                        ),
+                        ..Default::default()
+                    })
+                    .await;
+            }
+        }
+
     }
 
     debug!(

--- a/server/src/dirigent_proxy.rs
+++ b/server/src/dirigent_proxy.rs
@@ -42,6 +42,7 @@ use tokio::runtime::{Builder, Runtime};
 use tokio::signal::unix::SignalKind;
 use tokio::sync::{mpsc, oneshot};
 use tokio::{io, try_join};
+use tokio::time::{sleep, Duration};
 
 // Stuff needed for mTLS
 use anyhow::{anyhow, bail, Context as AnyhowContext, Result};
@@ -895,6 +896,7 @@ fn parse_nghttp2_codec_output(
     Vec<Vec<u8>>, // body_received_list
     Vec<String>,  // header_authority_value_string_list
     Vec<String>,  // header_x_anakonda_forward_value_string_list
+    Vec<String>,  // header_status_string_list
 ) {
     // ************************
     // *** parse the output ***
@@ -970,6 +972,7 @@ fn parse_nghttp2_codec_output(
     let mut body_received_list: Vec<Vec<u8>> = Vec::new();
     let mut header_authority_value_string_list: Vec<String> = Vec::new();
     let mut header_x_anakonda_forward_value_string_list: Vec<String> = Vec::new();
+    let mut header_status_value_string_list: Vec<String> = Vec::new();
     for idx_req_resp in 0..num_of_req_or_res_received {
         let set_idx = idx_req_resp + 1;
 
@@ -983,6 +986,8 @@ fn parse_nghttp2_codec_output(
         let header_authority_value_string;
         let mut header_x_anakonda_forward_value: Vec<u8> = Vec::new();
         let header_x_anakonda_forward_value_string;
+        let mut header_status_value: Vec<u8> = Vec::new();
+        let header_status_value_string;
 
         assert_eq!(10, response.sets[set_idx].items.len());
 
@@ -1028,6 +1033,15 @@ fn parse_nghttp2_codec_output(
                     debug!(
                         "codec header_authority_value length: {}",
                         header_authority_value.len()
+                    );
+                }
+                6 => {
+                    header_status_value.clear();
+                    header_status_value.extend_from_slice(output_item_data);
+
+                    debug!(
+                        "codec header_status_value length: {}",
+                        header_status_value.len()
                     );
                 }
                 7 => {
@@ -1078,6 +1092,13 @@ fn parse_nghttp2_codec_output(
             header_x_anakonda_forward_value_string
         );
         header_x_anakonda_forward_value_string_list.push(header_x_anakonda_forward_value_string);
+
+        header_status_value_string = String::from_utf8(header_status_value).unwrap();
+        debug!(
+            "codec header_status_value: {}",
+            header_status_value_string
+        );
+        header_status_value_string_list.push(header_status_value_string); 
     }
 
     // debug!("headers_received_list: {:?}", headers_received_list);
@@ -1105,6 +1126,7 @@ fn parse_nghttp2_codec_output(
         body_received_list,
         header_authority_value_string_list,
         header_x_anakonda_forward_value_string_list,
+        header_status_value_string_list,
     )
 }
 
@@ -1124,6 +1146,12 @@ struct StreamWorkerToRouterReq {
 }
 
 #[derive(Debug)]
+struct StreamWorkerToRouterReport5xxErrorReq {
+    header_x_anakonda_forward_value_string: String, // The url
+}
+
+
+#[derive(Debug)]
 struct RouterToStreamWorkerResp {
     payload: String,
     stream_worker_to_func_connection_worker_tx: mpsc::Sender<StreamWorkerToFuncConnReq>,
@@ -1134,6 +1162,7 @@ struct RouterToStreamWorkerResp {
 
 struct FunctionConnToStreamWorkerResp {
     payload: String,
+    resp_status: String,
     num_of_headers_to_send: usize,
     trailer_offset: i32,
     num_of_trailers_to_send: usize,
@@ -1501,6 +1530,7 @@ async fn func_connection_worker3(
         let mut body_received_list: Vec<Vec<u8>>;
         let mut header_authority_value_string_list: Vec<String>;
         let mut header_x_anakonda_forward_value_string_list: Vec<String>;
+        let mut header_status_value_string_list: Vec<String>;
 
         (
             // set 0
@@ -1518,6 +1548,7 @@ async fn func_connection_worker3(
             body_received_list,
             header_authority_value_string_list,
             header_x_anakonda_forward_value_string_list,
+            header_status_value_string_list,
         ) = parse_nghttp2_codec_output(function_output, recorder);
         size_of_session_state = session_state.len();
 
@@ -1575,6 +1606,7 @@ async fn func_connection_worker3(
             let num_of_trailers: usize = num_of_trailers_list[i];
             let headers_received: Vec<u8> = headers_received_list.remove(0);
             let body_received: Vec<u8> = body_received_list.remove(0);
+            let resp_status = header_status_value_string_list.remove(0);
             let channel_to_stream_worker = stream_worker_map.remove(&stream_id);
 
             info!("[func_connection_worker3. Local Addr: {}; Peer Addr: {}] receives a resp from uc with stream id: {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id);
@@ -1585,6 +1617,7 @@ async fn func_connection_worker3(
 
                     c.send(FunctionConnToStreamWorkerResp {
                         payload: format!("get resp from user func"),
+                        resp_status: resp_status,
                         num_of_headers_to_send: num_of_headers,
                         trailer_offset: trailer_offset,
                         num_of_trailers_to_send: num_of_trailers,
@@ -1608,190 +1641,299 @@ async fn router(
     nghttp2_codec_func_name: String,
     request_sender: mpsc::Sender<DispatcherCommand>,
     mut stream_worker_to_router_rx: mpsc::Receiver<StreamWorkerToRouterReq>,
+    mut stream_worker_to_router_report_5xx_error_rx: mpsc::Receiver<StreamWorkerToRouterReport5xxErrorReq>,
 ) {
     let config = dandelion_server::config::DandelionConfig::get_config();
     let max_tcp_connections = config.max_tcp_connections;
     let max_http2_pending_requests = config.max_http2_pending_requests;
-    info!("[Router] max_tcp_connections: {}, max_http2_pending_requests: {}", max_tcp_connections, max_http2_pending_requests);
+    let max_consecutive_5xx_errors = config.consecutive_5xx_errors;
+    let outlier_check_interval = config.outlier_check_interval;
+    let base_ejection_time = config.base_ejection_time;
+    info!("[Router] max_tcp_connections: {}, max_http2_pending_requests: {}, max_consecutive_5xx_errors: {}", max_tcp_connections, max_http2_pending_requests, max_consecutive_5xx_errors);
 
-    // key: url; value: connection pool
-    let mut uc_connections2: HashMap<String, (u32, u32, Vec<FuncConnTuple>)> = 
+    // key: url; value: (ejected, already_achieve_max_num_consecutive_5xx_errors, previous_result_is_5xx, num_consecutive_5xx_errors, num_pending_reqs)
+    let mut uc_connections2: HashMap<String, (bool, bool, bool, usize, u32, Vec<FuncConnTuple>)> = 
         HashMap::new();
 
+    // If we receive sth from this channel, it's the time to check the outlier; (used within the router)
+    // If we have achieved the max num of consecutive 5xx errors in the last interval, eject the sandbox/url
+    let (time_to_check_outlier_tx, mut time_to_check_outlier_check_rx) = mpsc::channel::<u8>(32);
+    let time_to_check_outlier_tx_clone = time_to_check_outlier_tx.clone();
+    tokio::spawn(async move {
+        sleep(Duration::from_secs(outlier_check_interval)).await;
+        let _ = time_to_check_outlier_tx_clone.send(0).await;
+    });
+
+    // If we receive sth from this channel, put back the ejected url (used within the router)
+    let (put_back_ejected_url_tx, mut put_back_ejected_url_rx) = mpsc::channel::<String>(32);
+
+
     // Process requests from stream workers
-    while let Some(req) = stream_worker_to_router_rx.recv().await {
-        info!(
-            "[Router] receives the request with header authority: {} {}",
-            req.header_authority_value_string, req.header_x_anakonda_forward_value_string,
-        );
+    loop {
+        tokio::select! {
+            Some(_) = time_to_check_outlier_check_rx.recv() => {
+                // Check if we have achieved the max num of consecutive 5xx errors in the last interval
+                // itereate through the hashmap; check all the urls
+                for (destination_url_string, value) in uc_connections2.iter_mut() {
+                    let (
+                        ejected,
+                        already_achieve_max_num_consecutive_5xx_errors,
+                        _,
+                        _,
+                        _,
+                        _,
+                    ) = value;
 
-        // TODO: need to make sure that the user codec does not alter this header --> security concern
-        // ****** Based on the header_authority_value_sting, query the dirigent service to get the url ******
-        // ****** Based on the url, pick one connection and its corresponding func_conn_worker ******
-        let destination_url_string = req.header_x_anakonda_forward_value_string;
-        debug!(
-            "[Router] gets the url: {} from the dirigent service",
-            destination_url_string
-        );
+                    if *ejected == false && *already_achieve_max_num_consecutive_5xx_errors == true {
+                        *ejected = true;
 
-        let stream_worker_to_func_connection_worker_tx: mpsc::Sender<StreamWorkerToFuncConnReq>;
-        let stream_worker_to_func_connection_worker_rx: mpsc::Receiver<StreamWorkerToFuncConnReq>;
+                        info!("[Router] Eject the url: {}", destination_url_string);
 
-        // *** Check if there is a need to create a new connection ***
-        let mut need_to_create_a_new_connection: bool = false;
-        let mut circuit_break: bool = false;
-        let mut circuit_break_resp_status: String = String::from("");
-        let mut circuit_break_resp_body: String = String::from("");
-        let mut selected_conn_idx: usize = 0;
-        if uc_connections2.contains_key(&destination_url_string) {
+                        let destination_url_string_clone = (*destination_url_string).clone();
+                        let put_back_ejected_url_tx_clone = put_back_ejected_url_tx.clone();
+                        tokio::spawn(async move {
+                            sleep(Duration::from_secs(base_ejection_time)).await;
+                            let _ = put_back_ejected_url_tx_clone.send(destination_url_string_clone).await;
+                        });
 
-            let (num_consecutive_errors, _, vec_func_conn_tuple) = uc_connections2
-                .get_mut(&destination_url_string)
-                .unwrap();
-
-            let mut i = 0;
-
-            // Iterate through the current connection pool
-            while i < vec_func_conn_tuple.len() {
-                // if the conn is already closed, remove it
-                if vec_func_conn_tuple[i].stream_worker_to_func_connection_worker_tx.is_closed() {
-                    info!("[Router] The func connection(url: {}, conn_id: {}) is already closed. Remove it from the pool", destination_url_string, vec_func_conn_tuple[i].conn_id);
-                    vec_func_conn_tuple.remove(i);
-                    continue;
-                }
-
-                // Check the num of pending reqs on ths conn
-                let (func_conn_worker_to_router_tx, func_conn_worker_to_router_rx) =
-                    oneshot::channel::<usize>();
-
-                let _  = vec_func_conn_tuple[i].router_to_func_connection_worker_tx.send(
-                    RouterToFuncConnReq {
-                        function_connection_worker_to_router_tx: func_conn_worker_to_router_tx
-                    }
-                ).await;
-
-                match func_conn_worker_to_router_rx.await {
-                    Ok(num) => {
-                        vec_func_conn_tuple[i].num_pending_reqs = num;
-                        debug!(
-                            "[Router] gets the numbder of pending requests on func conn (url: {}, conn_id: {}): {}",
-                            destination_url_string, 
-                            vec_func_conn_tuple[i].conn_id,
-                            vec_func_conn_tuple[i].num_pending_reqs
-                        );  
-                    }
-                    Err(e) => {
-                        error!(
-                            "[Router] fails to get the num of pending requests on func conn (url: {}, conn_id: {}) with error: {}",
-                            destination_url_string, 
-                            vec_func_conn_tuple[i].conn_id,
-                            e
-                        );                           
                     }
                 }
+                
 
-                if vec_func_conn_tuple[i].num_pending_reqs < max_http2_pending_requests { // we pick this conn if the num of pending requests is less than the threshold
-                    selected_conn_idx = i;
-                    break;
-                }
-
-                i += 1;
+                let time_to_check_outlier_tx_clone = time_to_check_outlier_tx.clone();
+                tokio::spawn(async move {
+                    sleep(Duration::from_secs(outlier_check_interval)).await;
+                    let _ = time_to_check_outlier_tx_clone.send(0).await;
+                });                
             }
+            Some(destination_url_string) = put_back_ejected_url_rx.recv() => {
+                let (ejected, already_achieve_max_num_consecutive_5xx_errors, previous_result_is_5xx, current_num_consecutive_errors, _, _) = uc_connections2
+                    .get_mut(&destination_url_string)
+                    .unwrap();
+                *ejected = false;
+                *already_achieve_max_num_consecutive_5xx_errors = false;
+                *previous_result_is_5xx = false;
+                *current_num_consecutive_errors = 0;
+                *current_num_consecutive_errors = 0;
 
-            // all connections in the pool has a max num of pending reqs
-            if i >= vec_func_conn_tuple.len() {
-                need_to_create_a_new_connection = true;
+                info!("[Router] put back the ejected url {}", destination_url_string);
             }
-
-            // Check if we have already achieved the max num of connections
-            if need_to_create_a_new_connection == true && vec_func_conn_tuple.len() >= max_tcp_connections {
-                info!("[Router] circuit breaking (url: {}), exceed max num of pending requests and connections", 
-                    destination_url_string, 
+            Some(req) = stream_worker_to_router_rx.recv() => {
+                info!(
+                    "[Router] receives the request with header authority: {} {}",
+                    req.header_authority_value_string, req.header_x_anakonda_forward_value_string,
                 );
-                need_to_create_a_new_connection = false;
-                circuit_break = true;
-                circuit_break_resp_status = String::from("503\0");
-                circuit_break_resp_body = String::from("Service Unavailable: exceed max num of pending requests and connections");
-            }
-        } else {
-            need_to_create_a_new_connection = true;
-            uc_connections2.insert(destination_url_string.clone(), (0, 0, Vec::new()));
-        }
 
-        if need_to_create_a_new_connection == true {
-            let (_, new_conn_id, vec_func_conn_tuple) = uc_connections2
-                .get_mut(&destination_url_string)
-                .unwrap();
+                // TODO: need to make sure that the user codec does not alter this header --> security concern
+                // ****** Based on the header_authority_value_sting, query the dirigent service to get the url ******
+                // ****** Based on the url, pick one connection and its corresponding func_conn_worker ******
+                let destination_url_string = req.header_x_anakonda_forward_value_string;
+                debug!(
+                    "[Router] gets the url: {} from the dirigent service",
+                    destination_url_string
+                );
 
-            (
-                stream_worker_to_func_connection_worker_tx,
-                stream_worker_to_func_connection_worker_rx,
-            ) = mpsc::channel::<StreamWorkerToFuncConnReq>(32);
+                let stream_worker_to_func_connection_worker_tx: mpsc::Sender<StreamWorkerToFuncConnReq>;
+                let stream_worker_to_func_connection_worker_rx: mpsc::Receiver<StreamWorkerToFuncConnReq>;
 
-            let (
-                router_to_func_connection_worker_tx,
-                router_to_func_connection_worker_rx,
-            ) = mpsc::channel::<RouterToFuncConnReq>(32);
+                // *** Check if there is a need to create a new connection ***
+                let mut need_to_create_a_new_connection: bool = false;
+                let mut circuit_break: bool = false;
+                let mut circuit_break_resp_status: String = String::from("");
+                let mut circuit_break_resp_body: String = String::from("");
+                let mut selected_conn_idx: usize = 0;
+                if uc_connections2.contains_key(&destination_url_string) {
 
-            match TcpStream::connect(&destination_url_string).await {
-                Ok(s) => {
-                    info!(
-                        "[Router] creates a new connection to {}",
+                    let (ejected, already_achieve_max_num_consecutive_5xx_errors, _, num_consecutive_errors, _, vec_func_conn_tuple) = uc_connections2
+                        .get_mut(&destination_url_string)
+                        .unwrap();
+
+                    if *ejected == true { // If ejected
+                        info!("[Router] circuit breaking (url: {}), exceed max num of consecutive 5xx errors", 
+                            destination_url_string, 
+                        );
+                        need_to_create_a_new_connection = false;
+                        circuit_break = true;
+                        circuit_break_resp_status = String::from("504\0");
+                        circuit_break_resp_body = String::from("Service Unavailable: exceed max num of consecutive 5xx errors");
+                    }
+                    else {
+                        let mut i = 0;
+
+                        // Iterate through the current connection pool
+                        while i < vec_func_conn_tuple.len() {
+                            // if the conn is already closed, remove it
+                            if vec_func_conn_tuple[i].stream_worker_to_func_connection_worker_tx.is_closed() {
+                                info!("[Router] The func connection(url: {}, conn_id: {}) is already closed. Remove it from the pool", destination_url_string, vec_func_conn_tuple[i].conn_id);
+                                vec_func_conn_tuple.remove(i);
+                                continue;
+                            }
+
+                            // Check the num of pending reqs on ths conn
+                            let (func_conn_worker_to_router_tx, func_conn_worker_to_router_rx) =
+                                oneshot::channel::<usize>();
+
+                            let _  = vec_func_conn_tuple[i].router_to_func_connection_worker_tx.send(
+                                RouterToFuncConnReq {
+                                    function_connection_worker_to_router_tx: func_conn_worker_to_router_tx
+                                }
+                            ).await;
+
+                            match func_conn_worker_to_router_rx.await {
+                                Ok(num) => {
+                                    vec_func_conn_tuple[i].num_pending_reqs = num;
+                                    debug!(
+                                        "[Router] gets the numbder of pending requests on func conn (url: {}, conn_id: {}): {}",
+                                        destination_url_string, 
+                                        vec_func_conn_tuple[i].conn_id,
+                                        vec_func_conn_tuple[i].num_pending_reqs
+                                    );  
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "[Router] fails to get the num of pending requests on func conn (url: {}, conn_id: {}) with error: {}",
+                                        destination_url_string, 
+                                        vec_func_conn_tuple[i].conn_id,
+                                        e
+                                    );                           
+                                }
+                            }
+
+                            if vec_func_conn_tuple[i].num_pending_reqs < max_http2_pending_requests { // we pick this conn if the num of pending requests is less than the threshold
+                                selected_conn_idx = i;
+                                break;
+                            }
+
+                            i += 1;
+                        }
+
+                        // all connections in the pool has a max num of pending reqs
+                        if i >= vec_func_conn_tuple.len() {
+                            need_to_create_a_new_connection = true;
+                        }
+
+                        // Check if we have already achieved the max num of connections
+                        if need_to_create_a_new_connection == true && vec_func_conn_tuple.len() >= max_tcp_connections {
+                            info!("[Router] circuit breaking (url: {}), exceed max num of pending requests and connections", 
+                                destination_url_string, 
+                            );
+                            need_to_create_a_new_connection = false;
+                            circuit_break = true;
+                            circuit_break_resp_status = String::from("503\0");
+                            circuit_break_resp_body = String::from("Service Unavailable: exceed max num of pending requests and connections");
+                        }
+
+                    }
+                } else {
+                    need_to_create_a_new_connection = true;
+                    uc_connections2.insert(destination_url_string.clone(), (false, false, false, 0, 0, Vec::new()));
+                }
+
+                if need_to_create_a_new_connection == true {
+                    let (_,_,  _, _, new_conn_id, vec_func_conn_tuple) = uc_connections2
+                        .get_mut(&destination_url_string)
+                        .unwrap();
+
+                    (
+                        stream_worker_to_func_connection_worker_tx,
+                        stream_worker_to_func_connection_worker_rx,
+                    ) = mpsc::channel::<StreamWorkerToFuncConnReq>(32);
+
+                    let (
+                        router_to_func_connection_worker_tx,
+                        router_to_func_connection_worker_rx,
+                    ) = mpsc::channel::<RouterToFuncConnReq>(32);
+
+                    match TcpStream::connect(&destination_url_string).await {
+                        Ok(s) => {
+                            info!(
+                                "[Router] creates a new connection to {}",
+                                destination_url_string
+                            );
+                            let stream = s;
+
+                            tokio::spawn(func_connection_worker3(
+                                nghttp2_codec_func_name.clone(),
+                                stream,
+                                request_sender.clone(),
+                                stream_worker_to_func_connection_worker_rx,
+                                router_to_func_connection_worker_rx,
+                            ));
+
+                            vec_func_conn_tuple.push(FuncConnTuple {
+                                conn_id: *new_conn_id,
+                                stream_worker_to_func_connection_worker_tx: stream_worker_to_func_connection_worker_tx.clone(),
+                                router_to_func_connection_worker_tx: router_to_func_connection_worker_tx.clone(),
+                                num_pending_reqs: 0,
+                            });
+                            *new_conn_id = *new_conn_id + 1;
+                        }
+                        Err(e) => {
+                            error!(
+                                "[Router] establish connection to {} with  error: {}",
+                                destination_url_string, e
+                            );
+                        }
+                    }
+                } 
+                else {
+                    debug!(
+                        "[Router] already has a connection to {}",
                         destination_url_string
                     );
-                    let stream = s;
 
-                    tokio::spawn(func_connection_worker3(
-                        nghttp2_codec_func_name.clone(),
-                        stream,
-                        request_sender.clone(),
-                        stream_worker_to_func_connection_worker_rx,
-                        router_to_func_connection_worker_rx,
-                    ));
+                    let (_, _, _, _, _, vec_func_conn_tuple) = uc_connections2
+                        .get_mut(&destination_url_string)
+                        .unwrap();
 
-                    vec_func_conn_tuple.push(FuncConnTuple {
-                        conn_id: *new_conn_id,
-                        stream_worker_to_func_connection_worker_tx: stream_worker_to_func_connection_worker_tx.clone(),
-                        router_to_func_connection_worker_tx: router_to_func_connection_worker_tx.clone(),
-                        num_pending_reqs: 0,
-                    });
-                    *new_conn_id = *new_conn_id + 1;
+                    stream_worker_to_func_connection_worker_tx = 
+                        vec_func_conn_tuple[selected_conn_idx].stream_worker_to_func_connection_worker_tx.clone();
                 }
-                Err(e) => {
-                    error!(
-                        "[Router] establish connection to {} with  error: {}",
-                        destination_url_string, e
-                    );
-                }
+
+                // Send the answer to the stream worker
+                let router_to_stream_worker_reply = RouterToStreamWorkerResp {
+                    payload: format!("router processed the request: {}", req.payload),
+                    stream_worker_to_func_connection_worker_tx: stream_worker_to_func_connection_worker_tx
+                        .clone(),
+                    circuit_break: circuit_break,
+                    cb_response_status: circuit_break_resp_status,
+                    cb_response_body: circuit_break_resp_body,
+                };
+                let _ = req
+                    .router_to_stream_worker_tx
+                    .send(router_to_stream_worker_reply);           
             }
-        } 
-        else {
-            debug!(
-                "[Router] already has a connection to {}",
-                destination_url_string
-            );
+            Some(req) = stream_worker_to_router_report_5xx_error_rx.recv() => {
+                let destination_url_string = req.header_x_anakonda_forward_value_string;
+                if uc_connections2.contains_key(&destination_url_string) {
+                    let (ejected, already_achieve_max_num_consecutive_5xx_errors, previous_resp_is_5xx, current_num_consecutive_5xx_errors, _, _) = uc_connections2
+                        .get_mut(&destination_url_string)
+                        .unwrap();
 
-            let (_, _, vec_func_conn_tuple) = uc_connections2
-                .get_mut(&destination_url_string)
-                .unwrap();
+                    if *ejected == false && *already_achieve_max_num_consecutive_5xx_errors == false { // The sandbox is not ejected; we havn't achieved the max num of consecutive 5xx errors in the last interval
+                        if *previous_resp_is_5xx == true {
+                            *current_num_consecutive_5xx_errors = *current_num_consecutive_5xx_errors + 1;
+                        }
+                        else {
+                            *previous_resp_is_5xx = true;
+                            *current_num_consecutive_5xx_errors = 1;
+                        }
 
-            stream_worker_to_func_connection_worker_tx = 
-                vec_func_conn_tuple[selected_conn_idx].stream_worker_to_func_connection_worker_tx.clone();
+                        if *current_num_consecutive_5xx_errors >= max_consecutive_5xx_errors { // circuit break
+                            *already_achieve_max_num_consecutive_5xx_errors = true;
+
+                            debug!("[Router] url {} achieves the max consecutive 5xx errors", destination_url_string);
+                        }
+                    }
+                } else {
+                    error!("[Router] does not has the connection pool to the {}", destination_url_string);
+                }
+
+
+            }
         }
-
-        // Send the answer to the stream worker
-        let router_to_stream_worker_reply = RouterToStreamWorkerResp {
-            payload: format!("router processed the request: {}", req.payload),
-            stream_worker_to_func_connection_worker_tx: stream_worker_to_func_connection_worker_tx
-                .clone(),
-            circuit_break: circuit_break,
-            cb_response_status: circuit_break_resp_status,
-            cb_response_body: circuit_break_resp_body,
-        };
-        let _ = req
-            .router_to_stream_worker_tx
-            .send(router_to_stream_worker_reply);
     }
+ 
 
     debug!("[Router] all channels to the router are closed; Router stops working");
 }
@@ -1852,6 +1994,16 @@ pub fn parse_headers(buf: &[u8]) -> Result<Vec<(String, String)>, String> {
     Ok(out)
 }
 
+// Check is the :status string is a 5xx error
+fn is_5xx(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    bytes.len() == 3
+        && bytes[0] == b'5'
+        && bytes[1].is_ascii_digit()
+        && bytes[2].is_ascii_digit()
+}
+
+
 // It handles one HTTP2 req-resp pair
 // It is launched by the dp_conn worker
 // It receives the HTTP2 Request from the dp_conn_worker, query the router and forwards it to the func_conn_worker.
@@ -1867,6 +2019,7 @@ async fn stream_worker(
     body_received: Vec<u8>,
     stream_worker_to_dp_connection_worker_tx: mpsc::Sender<StreamWorkerToDpConnReq>,
     stream_worker_to_router_tx: mpsc::Sender<StreamWorkerToRouterReq>,
+    stream_worker_to_router_report_5xx_error_tx: mpsc::Sender<StreamWorkerToRouterReport5xxErrorReq>,
     stream_id: i32,
     tcp_conn_local_addr: SocketAddr, // just for log
     tcp_conn_peer_addr: SocketAddr,  // just for log
@@ -1970,7 +2123,7 @@ async fn stream_worker(
         .send(StreamWorkerToRouterReq {
             payload: format!("request from stream worker: {}", stream_id),
             header_authority_value_string: header_authority_value_string,
-            header_x_anakonda_forward_value_string: header_x_anakonda_forward_value_string,
+            header_x_anakonda_forward_value_string: header_x_anakonda_forward_value_string.clone(),
             router_to_stream_worker_tx: router_to_stream_worker_tx,
         })
         .await
@@ -2057,7 +2210,18 @@ async fn stream_worker(
             // *** Wait for the resp from the user func conn worker ***
             match function_connection_worker_to_stream_worker_rx.await {
                 Ok(resp) => {
-                    info!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] gets resp from the user func conn worker", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id);
+                    info!("[stream_worker. Local Addr: {}; Peer Addr: {}; Stream ID:{}] gets resp from the user func conn worker with status {}", tcp_conn_local_addr, tcp_conn_peer_addr, stream_id, &resp.resp_status);
+
+                    // Check the resp status: is it a 5xx error?
+                    let resp_status_is_5xx = is_5xx(&resp.resp_status);
+
+                    if resp_status_is_5xx == true {
+                        let _ = stream_worker_to_router_report_5xx_error_tx
+                            .send(StreamWorkerToRouterReport5xxErrorReq { 
+                                header_x_anakonda_forward_value_string 
+                            })
+                            .await;
+                    }
 
                     let _ = stream_worker_to_dp_connection_worker_tx
                         .send(StreamWorkerToDpConnReq {
@@ -2116,6 +2280,7 @@ async fn dp_connection_worker3<S: ProxyStream>(
     mut stream: S,
     request_sender: mpsc::Sender<DispatcherCommand>,
     stream_worker_to_router_tx: mpsc::Sender<StreamWorkerToRouterReq>,
+    stream_worker_to_router_report_5xx_error_tx: mpsc::Sender<StreamWorkerToRouterReport5xxErrorReq>,
     authorization_policy_func_name: String,
     jwt_policy_func_name: String,
     jwt_pem_context: Arc<Context>,
@@ -2348,6 +2513,7 @@ async fn dp_connection_worker3<S: ProxyStream>(
         let mut body_received_list: Vec<Vec<u8>>;
         let mut header_authority_value_string_list: Vec<String>;
         let mut header_x_anakonda_forward_value_string_list: Vec<String>;
+        let mut header_status_value_string_list: Vec<String>;
 
         (
             // set 0
@@ -2365,6 +2531,7 @@ async fn dp_connection_worker3<S: ProxyStream>(
             body_received_list,
             header_authority_value_string_list,
             header_x_anakonda_forward_value_string_list,
+            header_status_value_string_list,
         ) = parse_nghttp2_codec_output(function_output, recorder);
 
         size_of_session_state = session_state.len();
@@ -2409,6 +2576,7 @@ async fn dp_connection_worker3<S: ProxyStream>(
                 body_received,
                 stream_worker_to_dp_connection_worker_tx.clone(),
                 stream_worker_to_router_tx.clone(),
+                stream_worker_to_router_report_5xx_error_tx.clone(),
                 stream_id,
                 stream.local_addr().unwrap(),
                 stream.peer_addr().unwrap(),
@@ -2490,10 +2658,14 @@ async fn create_proxy_server2(
     let (stream_worker_to_router_tx, stream_worker_to_func_router_rx) =
         mpsc::channel::<StreamWorkerToRouterReq>(32);
 
+    let (stream_worker_to_router_report_5xx_error_tx, stream_worker_to_func_router_report_5xx_error_rx) =
+        mpsc::channel::<StreamWorkerToRouterReport5xxErrorReq>(32);
+
     tokio::spawn(router(
         nghttp2_codec_func_name.clone(),
         request_sender.clone(),
         stream_worker_to_func_router_rx,
+        stream_worker_to_func_router_report_5xx_error_rx,
     ));
 
     // ****** The listening socket (for the data plane connections)******
@@ -2520,6 +2692,7 @@ async fn create_proxy_server2(
                 let proxy_tls_material_dir = proxy_tls_material_dir.clone();
 
                 let stream_worker_to_router_tx_clone = stream_worker_to_router_tx.clone();
+                let stream_worker_to_router_report_5xx_error_tx_clone = stream_worker_to_router_report_5xx_error_tx.clone();
 
                 // for each new dp connection spawn a dp connection worker
                 let func_name = nghttp2_codec_func_name.clone();
@@ -2584,7 +2757,7 @@ async fn create_proxy_server2(
 
                                 let stream = DpStream::new(tls_stream, local_addr, peer_addr);
                                 let service_dispatcher_ptr = loop_dispatcher.clone();
-                                dp_connection_worker3(func_name, stream, service_dispatcher_ptr.clone(), stream_worker_to_router_tx_clone.clone(), authorization_policy_func_name, jwt_policy_func_name, jwt_pem_context, enable_authorization_policy, enable_jwt_policy).await;
+                                dp_connection_worker3(func_name, stream, service_dispatcher_ptr.clone(), stream_worker_to_router_tx_clone.clone(), stream_worker_to_router_report_5xx_error_tx_clone.clone(), authorization_policy_func_name, jwt_policy_func_name, jwt_pem_context, enable_authorization_policy, enable_jwt_policy).await;
                             }
                             Err (err) => {
                                 warn!("mTLS handshake failed from {}: {:?}", peer_addr, err);
@@ -2595,7 +2768,7 @@ async fn create_proxy_server2(
                 else {
                     tokio::spawn(async move {
                         let service_dispatcher_ptr = loop_dispatcher.clone();
-                        dp_connection_worker3(func_name, tcp_stream, service_dispatcher_ptr.clone(), stream_worker_to_router_tx_clone.clone(), authorization_policy_func_name, jwt_policy_func_name, jwt_pem_context, enable_authorization_policy, enable_jwt_policy).await;
+                        dp_connection_worker3(func_name, tcp_stream, service_dispatcher_ptr.clone(), stream_worker_to_router_tx_clone.clone(), stream_worker_to_router_report_5xx_error_tx_clone.clone(), authorization_policy_func_name, jwt_policy_func_name, jwt_pem_context, enable_authorization_policy, enable_jwt_policy).await;
                     });
                 }
 


### PR DESCRIPTION
For each url, there is now a connection pool.

Circuit Breaking: 
max_tcp_connections, max_htttp2_pending_requests, consecutive_5xx_errors, outlier_check_interval, base_ejection_time

Retrying:
max_retry_times, per_retry_timeout