### PR TITLE
Any Sharding

### DIFF
--- a/dandelion_commons/src/lib.rs
+++ b/dandelion_commons/src/lib.rs
@@ -157,6 +157,19 @@ macro_rules! err_dandelion {
     };
 }
 
+/// Tries to create a new instance of the given type with given capacity and returns a
+/// `DandelionError::OutOfMemory` if it fails.
+#[macro_export]
+macro_rules! try_with_capacity {
+    ($type:ident, $size:expr) => {{
+        let mut container = $type::new();
+        container
+            .try_reserve($size)
+            .map(|_| container)
+            .map_err(|_| dandelion_err!(DandelionError::OutOfMemory))
+    }};
+}
+
 // Implement display to be compliant with core::error::Error
 impl core::fmt::Display for DandelionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -276,6 +289,10 @@ pub enum CompositionError {
     FunctionInvalidIdentifier(String),
     /// Set indentifier is produced by multiple functions in a composition
     DuplicateSetName,
+    /// Joining a set twice
+    InvalidSecondJoin(String),
+    /// Set joins (non cross join) either an all/each sharding or an anyKeyed with a keyed sharding.
+    InvalidJoinSharding(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/dispatcher/src/dispatcher.rs
+++ b/dispatcher/src/dispatcher.rs
@@ -397,7 +397,7 @@ impl Dispatcher {
                 .any(|opt| opt.is_some() && !opt.as_ref().unwrap().1.is_empty());
         let composition_results: DandelionResult<Vec<_>> = if is_sharded {
             // TODO: check how to best compute the target parallelism
-            let target_parallelism = 0;
+            let target_parallelism = usize::MAX;
             let sharded = get_sharding(input_sets, join_order, join_strategies, target_parallelism);
             let size_hint = sharded.len();
             recorders = Vec::with_capacity(size_hint);

--- a/dispatcher/src/dispatcher.rs
+++ b/dispatcher/src/dispatcher.rs
@@ -396,7 +396,9 @@ impl Dispatcher {
                 .iter()
                 .any(|opt| opt.is_some() && !opt.as_ref().unwrap().1.is_empty());
         let composition_results: DandelionResult<Vec<_>> = if is_sharded {
-            let sharded = get_sharding(input_sets, join_order, join_strategies);
+            // TODO: check how to best compute the target parallelism
+            let target_parallelism = 0;
+            let sharded = get_sharding(input_sets, join_order, join_strategies, target_parallelism);
             let size_hint = sharded.len();
             recorders = Vec::with_capacity(size_hint);
             let resutls: Vec<_> = sharded

--- a/dispatcher/src/function_registry.rs
+++ b/dispatcher/src/function_registry.rs
@@ -1,6 +1,6 @@
 use dandelion_commons::{
-    dandelion_err, err_dandelion, CompositionError, DandelionError, DandelionResult, FunctionId,
-    FunctionRegistryError,
+    dandelion_err, err_dandelion, try_with_capacity, CompositionError, DandelionError,
+    DandelionResult, FunctionId, FunctionRegistryError,
 };
 use dparser::print_errors;
 use itertools::Itertools;
@@ -339,9 +339,10 @@ impl FunctionRegistry {
                         };
                         set_counter += 1;
                     }
+
+                    // add composition output sets
                     let mut output_map = BTreeMap::new();
                     let output_sets_start = set_counter;
-                    // add composition output sets
                     for (output_index, output_set_name) in comp.v.returns.iter().enumerate() {
                         match set_numbers.entry(output_set_name.clone()) {
                             Entry::Vacant(v) => {
@@ -356,6 +357,7 @@ impl FunctionRegistry {
                         };
                     }
                     let output_sets_end = set_counter;
+
                     // add all return sets from functions
                     let composition_set_identifiers = comp
                         .v
@@ -403,9 +405,7 @@ impl FunctionRegistry {
                                     return err_dandelion!(DandelionError::Composition(CompositionError::ContainsInvalidFunction(function_application.v.name.clone())));
                                 }
                                 // find the indeces of the sets in the function application by looking though the definition
-                                let mut input_set_ids = Vec::new();
-                                input_set_ids
-                                    .try_reserve(function_decl.v.params.len()).map_err(|_| dandelion_err!(DandelionError::OutOfMemory))?;
+                                let mut input_set_ids = try_with_capacity!(Vec, function_decl.v.params.len())?;
                                 input_set_ids.resize(function_decl.v.params.len(), None);
                                 for argument in function_application.v.args.iter() {
                                     if let Some(index) =
@@ -438,35 +438,98 @@ impl FunctionRegistry {
                                 }
 
                                 // find the join order
-                                let mut all_sets: Vec<_> =
-                                    (0..function_decl.v.params.len())
-                                    .map(|index| Some(index)).collect();
-                                let mut join_set_order = Vec::new();
-                                join_set_order.try_reserve(function_decl.v.params.len())
-                                    .or(err_dandelion!(DandelionError::OutOfMemory))?;
-                                let mut join_strategies = Vec::new();
-                                join_strategies.try_reserve(function_decl.v.params.len())
-                                    .or(err_dandelion!(DandelionError::OutOfMemory))?;
+                                let num_params = function_decl.v.params.len();
+                                let mut processed_set = try_with_capacity!(Vec, num_params)?;
+                                processed_set.resize(function_decl.v.params.len(), false);
+                                let mut join_set_order = try_with_capacity!(Vec, num_params)?;
+                                let mut join_strategies = try_with_capacity!(Vec, num_params)?;
+                                let mut tmp_any_join_set_order = try_with_capacity!(Vec, num_params)?;
+                                let mut tmp_any_join_strategies = try_with_capacity!(Vec, num_params)?;
+                                let mut curr_join_chain_any = None;
                                 if let Some(strategy) = function_application.v.join_strategy.as_ref().and_then(|strategy| if strategy.join_strategy_order.is_empty() || strategy.join_strategies.is_empty() {None} else {Some(strategy)}) {
-                                    for set_name in strategy.join_strategy_order.iter() {
+                                    for (i, set_name) in strategy.join_strategy_order.iter().enumerate() {
+                                        // find set index
                                         let set_index = function_decl.v.params.iter()
                                             .position(|param_name| *param_name == *set_name)
                                             .ok_or_else(|| dandelion_err!(DandelionError::Composition(CompositionError::FunctionInvalidIdentifier(
                                                 format!("Join order for {} contains invalid set name: {}", function_application.v.name, set_name))
                                             )))?;
-                                        all_sets[set_index] = None;
-                                        join_set_order.push(set_index);
+
+                                        // check that this set has not already been processed
+                                        if processed_set[set_index] {
+                                            return err_dandelion!(DandelionError::Composition(CompositionError::InvalidSecondJoin(
+                                                format!("Joining set '{}' twice.", set_name)
+                                            )));
+                                        }
+                                        processed_set[set_index] = true;
+
+                                        // get strategy and add to the corresponding join order
+                                        if i > 0 {
+                                            let strategy = JoinStrategy::from_parser_strategy(&strategy.join_strategies[i-1]);
+                                            join_strategies.push(strategy);
+                                            if strategy == JoinStrategy::Cross {
+                                                curr_join_chain_any = None;
+                                            }
+                                        };
+                                        if let Some(set_id) = input_set_ids[set_index] {
+                                            match set_id.sharding {
+                                                ShardingMode::Key => {
+                                                    if let Some(is_any) = curr_join_chain_any {
+                                                        if is_any {
+                                                            return err_dandelion!(DandelionError::Composition(CompositionError::InvalidJoinSharding(
+                                                                format!("Mixing keyed and anyKeyed shardings: Encountered keyed while processing any chain for index {}", set_index)
+                                                            )));
+                                                        }
+                                                    }
+                                                    curr_join_chain_any = Some(false);
+                                                    join_set_order.push(set_index);
+                                                }
+                                                ShardingMode::AnyKey => {
+                                                    if let Some(is_any) = curr_join_chain_any {
+                                                        if !is_any {
+                                                            return err_dandelion!(DandelionError::Composition(CompositionError::InvalidJoinSharding(
+                                                                format!("Mixing keyed and anyKeyed shardings: Encountered anyKeyed while processing non-any chain for index {}", set_index)
+                                                            )));
+                                                        }
+                                                    }
+                                                    curr_join_chain_any = Some(true);
+                                                    tmp_any_join_set_order.push(set_index);
+                                                }
+                                                _ => return err_dandelion!(DandelionError::Composition(CompositionError::InvalidJoinSharding(
+                                                    format!("Joining set with non-keyed sharding (set_index: {}, sharding: {:?}", set_index, set_id.sharding)
+                                                ))),
+                                            }
+                                        }
                                     }
-                                    for join_strategy in strategy.join_strategies.iter() {
-                                        join_strategies.push(JoinStrategy::from_parser_strategy(&join_strategy))
+                                }
+                                // add remaining sets with keyed shardings that have no specific join order
+                                for (set_idx, set_id_opt) in input_set_ids.iter().enumerate() {
+                                    if processed_set[set_idx] {
+                                        continue;
                                     }
+                                    if let Some(set_id) = set_id_opt {
+                                        if set_id.sharding == ShardingMode::Key {
+                                            processed_set[set_idx] = true;
+                                            join_strategies.push(JoinStrategy::Cross);
+                                            join_set_order.push(set_idx);
+                                        }
+                                    }
+                                }
+                                // add joined any sets
+                                join_strategies.append(&mut tmp_any_join_strategies);
+                                join_set_order.append(&mut tmp_any_join_set_order);
+                                // fill up the remaining join order/strategy
+                                for (set_idx, is_processed) in processed_set.iter().enumerate() {
+                                    if !is_processed {
+                                        join_set_order.push(set_idx);
+                                    }
+                                }
+                                if join_set_order.len() > 0 {
+                                    join_strategies.resize(join_set_order.len() - 1, JoinStrategy::Cross);
                                 }
 
                                 // find the index set index in the original definition for each return set in the application
-                                let mut output_set_ids = Vec::new();
-                                output_set_ids
-                                    .try_reserve(function_decl.v.returns.len())
-                                    .or(err_dandelion!(DandelionError::OutOfMemory))?;
+                                let mut output_set_ids = try_with_capacity!(Vec, function_decl.v.returns.len())?;
                                 output_set_ids.resize(function_decl.v.returns.len(), None);
                                 for return_set in function_application.v.rets.iter() {
                                     if let Some(index) =

--- a/dispatcher/tests/dispatcher_tests/function_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/function_tests.rs
@@ -3,7 +3,8 @@ use dandelion_commons::{records::Recorder, FunctionId};
 use dispatcher::dispatcher::Dispatcher;
 use machine_interface::{
     composition::{
-        Composition, CompositionSet, FunctionDependencies, InputSetDescriptor, ShardingMode,
+        Composition, CompositionSet, FunctionDependencies, InputSetDescriptor, JoinStrategy,
+        ShardingMode,
     },
     function_driver::ComputeResource,
     machine_config::{DomainType, EngineType},
@@ -135,7 +136,7 @@ pub fn composition_single_matmul<Domain: MemoryDomain>(
     let composition = Composition {
         dependencies: vec![FunctionDependencies {
             function: function_id,
-            join_info: (vec![], vec![]),
+            join_info: (vec![0], vec![]),
             input_set_ids: vec![Some(InputSetDescriptor {
                 composition_id: 0,
                 sharding: ShardingMode::All,
@@ -207,7 +208,7 @@ pub fn composition_optional<Domain: MemoryDomain>(
     let composition1 = Composition {
         dependencies: vec![FunctionDependencies {
             function: function_id.clone(),
-            join_info: (vec![], vec![]),
+            join_info: (vec![0], vec![]),
             input_set_ids: vec![Some(InputSetDescriptor {
                 composition_id: 0,
                 sharding: ShardingMode::All,
@@ -226,7 +227,7 @@ pub fn composition_optional<Domain: MemoryDomain>(
     let composition2 = Composition {
         dependencies: vec![FunctionDependencies {
             function: function_id.clone(),
-            join_info: (vec![], vec![]),
+            join_info: (vec![0], vec![]),
             input_set_ids: vec![Some(InputSetDescriptor {
                 composition_id: 0,
                 sharding: ShardingMode::All,
@@ -245,7 +246,7 @@ pub fn composition_optional<Domain: MemoryDomain>(
     let composition3 = Composition {
         dependencies: vec![FunctionDependencies {
             function: function_id.clone(),
-            join_info: (vec![], vec![]),
+            join_info: (vec![0], vec![]),
             input_set_ids: vec![Some(InputSetDescriptor {
                 composition_id: 0,
                 sharding: ShardingMode::All,
@@ -264,7 +265,7 @@ pub fn composition_optional<Domain: MemoryDomain>(
     let composition4 = Composition {
         dependencies: vec![FunctionDependencies {
             function: function_id.clone(),
-            join_info: (vec![], vec![]),
+            join_info: (vec![0], vec![]),
             input_set_ids: vec![Some(InputSetDescriptor {
                 composition_id: 0,
                 sharding: ShardingMode::All,
@@ -290,7 +291,7 @@ pub fn composition_optional<Domain: MemoryDomain>(
             },
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (vec![0], vec![]),
                 input_set_ids: vec![Some(InputSetDescriptor {
                     composition_id: 1,
                     sharding: ShardingMode::All,
@@ -317,7 +318,7 @@ pub fn composition_optional<Domain: MemoryDomain>(
             },
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (vec![0], vec![]),
                 input_set_ids: vec![Some(InputSetDescriptor {
                     composition_id: 1,
                     sharding: ShardingMode::All,
@@ -382,7 +383,7 @@ pub fn composition_parallel_matmul<Domain: MemoryDomain>(
     let composition = Composition {
         dependencies: vec![FunctionDependencies {
             function: function_id,
-            join_info: (vec![], vec![]),
+            join_info: (vec![0], vec![]),
             input_set_ids: vec![Some(InputSetDescriptor {
                 composition_id: 0,
                 sharding: ShardingMode::Each,
@@ -461,7 +462,7 @@ pub fn composition_chain_matmul<Domain: MemoryDomain>(
         dependencies: vec![
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (vec![0], vec![]),
                 input_set_ids: vec![Some(InputSetDescriptor {
                     composition_id: 0,
                     sharding: ShardingMode::All,
@@ -471,7 +472,7 @@ pub fn composition_chain_matmul<Domain: MemoryDomain>(
             },
             FunctionDependencies {
                 function: function_id,
-                join_info: (vec![], vec![]),
+                join_info: (vec![0], vec![]),
                 input_set_ids: vec![Some(InputSetDescriptor {
                     composition_id: 1,
                     sharding: ShardingMode::All,
@@ -575,7 +576,10 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
             // C = A*B
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (
+                    vec![0, 1, 2],
+                    vec![JoinStrategy::Cross, JoinStrategy::Cross],
+                ),
                 input_set_ids: vec![
                     Some(InputSetDescriptor {
                         composition_id: 0,
@@ -594,7 +598,10 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
             // D = B^T*A
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (
+                    vec![0, 1, 2],
+                    vec![JoinStrategy::Cross, JoinStrategy::Cross],
+                ),
                 input_set_ids: vec![
                     Some(InputSetDescriptor {
                         composition_id: 2,
@@ -613,7 +620,10 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
             // E = B + C
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (
+                    vec![0, 1, 2],
+                    vec![JoinStrategy::Cross, JoinStrategy::Cross],
+                ),
                 input_set_ids: vec![
                     None,
                     Some(InputSetDescriptor {
@@ -632,7 +642,10 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
             // G = D * C
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (
+                    vec![0, 1, 2],
+                    vec![JoinStrategy::Cross, JoinStrategy::Cross],
+                ),
                 input_set_ids: vec![
                     Some(InputSetDescriptor {
                         composition_id: 4,
@@ -651,7 +664,10 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
             // Result = D*E + G
             FunctionDependencies {
                 function: function_id.clone(),
-                join_info: (vec![], vec![]),
+                join_info: (
+                    vec![0, 1, 2],
+                    vec![JoinStrategy::Cross, JoinStrategy::Cross],
+                ),
                 input_set_ids: vec![
                     Some(InputSetDescriptor {
                         composition_id: 4,
@@ -767,7 +783,10 @@ pub fn composition_chain_large_matmac<Domain: MemoryDomain>(
         // C+C, should be a matrix filled with 2s
         // also test that we can use the same set as mutliple input set for one function
         function: function_id.clone(),
-        join_info: (vec![], vec![]),
+        join_info: (
+            vec![0, 1, 2],
+            vec![JoinStrategy::Cross, JoinStrategy::Cross],
+        ),
         input_set_ids: vec![
             None,
             Some(InputSetDescriptor {
@@ -793,7 +812,10 @@ pub fn composition_chain_large_matmac<Domain: MemoryDomain>(
         };
         dependencies.push(FunctionDependencies {
             function: function_id.clone(),
-            join_info: (vec![], vec![]),
+            join_info: (
+                vec![0, 1, 2],
+                vec![JoinStrategy::Cross, JoinStrategy::Cross],
+            ),
             input_set_ids: vec![
                 None,
                 Some(InputSetDescriptor {

--- a/dparser/src/lib.rs
+++ b/dparser/src/lib.rs
@@ -42,6 +42,8 @@ pub enum Sharding {
     All,
     Keyed,
     Each,
+    AnyKeyed,
+    AnyEach,
 }
 
 pub type ALoopCond = Rc<Spanned<LoopCond>>;
@@ -217,14 +219,20 @@ fn parser() -> impl Parser<char, Module, Error = Simple<char>> {
         .then_ignore(just('=').padded())
         .then(just("optional").padded().or_not())
         .then(
-            (just("all").or(just("keyed")).or(just("each")))
-                .map(|sharding| match sharding {
-                    "all" => Sharding::All,
-                    "keyed" => Sharding::Keyed,
-                    "each" => Sharding::Each,
-                    _ => unreachable!(),
-                })
-                .padded(),
+            (just("all")
+                .or(just("keyed"))
+                .or(just("each"))
+                .or(just("anyKeyed"))
+                .or(just("anyEach")))
+            .map(|sharding| match sharding {
+                "all" => Sharding::All,
+                "keyed" => Sharding::Keyed,
+                "each" => Sharding::Each,
+                "anyKeyed" => Sharding::AnyKeyed,
+                "anyEach" => Sharding::AnyEach,
+                _ => unreachable!(),
+            })
+            .padded(),
         )
         .then(text::ident().padded())
         .map(|(((name, optional), sharding), ident)| InputDescriptor {
@@ -457,8 +465,8 @@ fn sharding_test() {
     
         FunB (
             A = keyed InputA,
-            B = keyed InputB,
-            C = keyed InputC
+            B = anyKeyed InputB,
+            C = anyEach InputC
         ) => (
             InterD = D
         );

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -2,7 +2,6 @@ use crate::memory_domain::{Context, ContextTrait};
 use dandelion_commons::{
     err_dandelion, DandelionError, DandelionResult, DispatcherError, FunctionId,
 };
-use itertools::Itertools;
 use std::{
     cmp,
     collections::{BTreeMap, HashMap, HashSet},
@@ -12,6 +11,8 @@ use std::{
 
 #[cfg(test)]
 use crate::memory_domain::read_only::ReadOnlyContext;
+#[cfg(test)]
+use itertools::Itertools;
 
 mod join_iterator;
 
@@ -388,6 +389,12 @@ fn compute_any_parallelism(
         curr_join_keys.clear();
     }
 
+    log::trace!(
+        "Found fixed_parallelism: {} (target_parallelism: {})",
+        fixed_parallelism,
+        target_parallelism
+    );
+
     // find the best suitable any set(s) and determine their parallelism
     if fixed_parallelism < target_parallelism && !any_groups.is_empty() {
         let mut leftover_parallelism = target_parallelism / fixed_parallelism;
@@ -464,6 +471,7 @@ pub fn get_sharding(
     // compute the parallelism of the any sets
     let any_set_parallelism =
         compute_any_parallelism(&sets, &join_order, &join_strategies, target_parallelism);
+    log::trace!("Computed any_set_parallelism: {:?}", any_set_parallelism);
 
     // create the iterators later used to generate the final sharding
     let mut join_iter = None;
@@ -541,8 +549,8 @@ pub fn get_sharding(
                     }
                 }
             }
-            i += 1;
         }
+        i += 1;
     }
 
     // generate the sharding sets

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -192,9 +192,11 @@ impl<'origin> IntoIterator for &'origin CompositionSet {
 }
 
 /// Computes the sharding for the given sets following the given join order and join strategies.
-/// The `join_strategies` vector is expected to be of size <= `join_order.len() - 1`.
+/// The `join_order` vector is expected to be of length `sets.len()`, the `join_strategies` vector
+/// is expected to be of size `sets.len() - 1`.
 /// The function tries to produce an output vector of size `target_parallelism` if possible grouping
-/// `AnyEach` and `AnyKey` sets accordingly or use a value of 0 to disable this.
+/// `AnyEach` and `AnyKey` sets accordingly. If a `target_parallelism` of 0 is given it will use
+/// maximum possible parallellism.
 pub fn get_sharding(
     mut sets: Vec<Option<(ShardingMode, CompositionSet)>>,
     join_order: Vec<usize>,
@@ -368,8 +370,10 @@ pub fn get_sharding(
             }
         }
     }
-    if let Some(iter) = join_iter.as_mut() {
-        iter.reduce_any_parallelism(any_parallelisms);
+    if target_parallelism > 0 {
+        if let Some(iter) = join_iter.as_mut() {
+            iter.reduce_any_parallelism(any_parallelisms);
+        }
     }
 
     // generate the sharding sets

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -388,7 +388,7 @@ fn compute_any_parallelism(
         curr_join_keys.clear();
     }
 
-    // determine the parallelism of
+    // find the best suitable any set(s) and determine their parallelism
     if fixed_parallelism < target_parallelism && !any_groups.is_empty() {
         let mut leftover_parallelism = target_parallelism / fixed_parallelism;
         loop {
@@ -432,10 +432,15 @@ fn compute_any_parallelism(
     any_set_parallelism
 }
 
+/// Computes the sharding for the given sets following the given join order and join strategies.
+/// The `join_strategies` vector is expected to be of size <= `join_order.len() - 1`.
+/// The function tries to produce an output vector of size `target_parallelism` if possible grouping
+/// `AnyEach` and `AnyKey` sets accordingly or use a value of 0 to disable this.
 pub fn get_sharding(
     mut sets: Vec<Option<(ShardingMode, CompositionSet)>>,
     mut join_order: Vec<usize>,
     mut join_strategies: Vec<JoinStrategy>,
+    target_parallelism: usize,
 ) -> Vec<Vec<Option<CompositionSet>>> {
     let set_num = sets.len();
     let mut final_sharding = Vec::new();
@@ -443,10 +448,6 @@ pub fn get_sharding(
     if set_num == 0 {
         return final_sharding;
     }
-
-    let target_parallelism = 10; // TODO: move to arg
-    let any_set_parallelism =
-        compute_any_parallelism(&sets, &join_order, &join_strategies, target_parallelism);
 
     // make sure every set is in the order and has a strategy
     let mut missing_sets: Vec<_> = (0..set_num).map(|index| Some(index)).collect();
@@ -460,9 +461,12 @@ pub fn get_sharding(
     }
     join_strategies.resize(set_num - 1, JoinStrategy::Cross);
 
+    // compute the parallelism of the any sets
+    let any_set_parallelism =
+        compute_any_parallelism(&sets, &join_order, &join_strategies, target_parallelism);
+
     // create the iterators later used to generate the final sharding
     let mut join_iter = None;
-    // for (i, set_idx) in join_order.iter().enumerate() {
     let mut i = 0;
     while i < join_order.len() {
         let set_idx = join_order[i];
@@ -494,6 +498,7 @@ pub fn get_sharding(
                             sharding,
                         );
                     } else {
+                        // TODO: do we want maximum parallelism in this case or zero parallelism?
                         // if we got no specific parallelism for this set we assume parallelism is 1
                         join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
                     }
@@ -505,7 +510,7 @@ pub fn get_sharding(
                         let mut joined_set_idcs = vec![set_idx];
                         let mut joined_strategies = vec![];
                         while i + 1 < join_order.len() {
-                            let next_strategy = join_strategies[i + 1];
+                            let next_strategy = join_strategies[i];
                             if next_strategy != JoinStrategy::Cross {
                                 let next_set_idx = join_order[i + 1];
                                 if let Some((_, set)) = sets[next_set_idx].take() {
@@ -530,6 +535,7 @@ pub fn get_sharding(
                             sharding,
                         );
                     } else {
+                        // TODO: do we want maximum parallelism in this case or zero parallelism?
                         // if we got no specific parallelism for this set we assume parallelism is 1
                         join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
                     }
@@ -555,307 +561,6 @@ pub fn get_sharding(
 
     final_sharding
 }
-
-// /// Structure to hold join iterator
-// #[derive(Debug)]
-// struct JoinIterator {
-//     left: Option<Box<JoinIterator>>,
-//     right: Vec<CompositionSet>,
-//     /// Index of the current interator into it's compositon set vector
-//     /// The current index points to the element set by the last successful advance call
-//     right_index: usize,
-//     write_index: usize,
-//     mode: JoinStrategy,
-//     key: u32,
-// }
-
-// impl JoinIterator {
-//     fn new(
-//         mode: JoinStrategy,
-//         mut left_opt: Option<Box<Self>>,
-//         right_opt: Option<(ShardingMode, CompositionSet)>,
-//         write_index: usize,
-//     ) -> Option<Box<Self>> {
-//         if right_opt.is_none() || right_opt.as_ref().unwrap().1.is_empty() {
-//             return left_opt;
-//         }
-//         let (set_mode, set) = right_opt.unwrap();
-//         let right = set.shard(set_mode);
-
-//         // we assume the keys of the sets are in descending order
-//         debug_assert!(right.is_sorted_by_key(|set| set.item_list[0].0));
-
-//         if right.is_empty() {
-//             return left_opt;
-//         }
-
-//         let mut right_index = 0;
-//         let mut key = right[0].item_list[0].0;
-
-//         if let Some(left) = &mut left_opt {
-//             match mode {
-//                 JoinStrategy::Inner => {
-//                     while right_index < right.len() && key != left.key {
-//                         if key < left.key {
-//                             right_index += 1;
-//                             if right_index < right.len() {
-//                                 key = right[right_index].item_list[0].0;
-//                             }
-//                         } else {
-//                             if !left.advance() {
-//                                 right_index = right.len();
-//                             }
-//                         }
-//                     }
-//                     if right_index == right.len() {
-//                         return None;
-//                     }
-//                 }
-//                 JoinStrategy::Left => {
-//                     while right_index < right.len() && right[right_index].item_list[0].0 < left.key
-//                     {
-//                         right_index += 1;
-//                     }
-//                     key = left.key;
-//                     if right_index == right.len() {
-//                         return left_opt;
-//                     }
-//                 }
-//                 JoinStrategy::Outer => {
-//                     if left.key < key {
-//                         key = left.key;
-//                     }
-//                     // else already has the correct key set
-//                 }
-//                 JoinStrategy::Right | JoinStrategy::Cross => (),
-//             }
-//         // there is not left iterator
-//         } else {
-//             match mode {
-//                 JoinStrategy::Inner | JoinStrategy::Left => {
-//                     return None;
-//                 }
-//                 _ => (),
-//             }
-//         }
-//         Some(Box::new(Self {
-//             left: left_opt,
-//             right,
-//             right_index: 0,
-//             write_index,
-//             mode,
-//             key,
-//         }))
-//     }
-
-//     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-//         let right_filled = self.right_index < self.right.len()
-//             && self.key == self.right[self.right_index].item_list[0].0;
-//         if right_filled {
-//             to_fill[self.write_index] = Some(self.right[self.right_index].clone());
-//         }
-//         if let Some(left) = &mut self.left {
-//             match self.mode {
-//                 // modes for which always want left to fill in
-//                 JoinStrategy::Cross | JoinStrategy::Left => left.fill_in(to_fill),
-//                 // Only want to fill left if it is the one with the current key
-//                 JoinStrategy::Outer => {
-//                     if self.key == left.key {
-//                         left.fill_in(to_fill)
-//                     }
-//                 }
-//                 // Only want left to fill if right has filled something in
-//                 JoinStrategy::Inner => {
-//                     if right_filled {
-//                         left.fill_in(to_fill)
-//                     }
-//                 }
-//                 // Only want left to fill if right has filled and the keys match
-//                 JoinStrategy::Right => {
-//                     if right_filled && self.key == left.key {
-//                         left.fill_in(to_fill)
-//                     }
-//                 }
-//             }
-//         };
-//     }
-
-//     /// Advance the iterator by one.
-//     /// Another advance call after a advance that returned false always returns false
-//     /// A fill_in call after a advance that called false is undefined behaviour.
-//     fn advance(&mut self) -> bool {
-//         // set this when there is no more adavnce calls to be had to shortcut evaluation
-//         if self.right_index == self.right.len() {
-//             return false;
-//         }
-//         let right = &mut self.right;
-//         if let Some(left) = &mut self.left {
-//             match self.mode {
-//                 JoinStrategy::Inner => {
-//                     // advance both at least once for inner
-//                     // left is advanced on checking (after checking right can stil be advanced)
-//                     // right is advanced after
-//                     if self.right_index + 1 >= right.len() || !left.advance() {
-//                         self.right_index = right.len();
-//                         return false;
-//                     }
-//                     self.right_index += 1;
-//                     self.key = right[self.right_index].item_list[0].0;
-//                     while self.key != left.key {
-//                         if self.key > left.key {
-//                             if !left.advance() {
-//                                 self.right_index = right.len();
-//                                 return false;
-//                             }
-//                         // need to advance right and are able to do so
-//                         } else if self.key < left.key {
-//                             if self.right_index + 1 >= right.len() {
-//                                 self.right_index = right.len();
-//                                 return false;
-//                             } else {
-//                                 self.right_index += 1;
-//                                 self.key = right[self.right_index].item_list[0].0;
-//                             }
-//                         }
-//                     }
-//                     true
-//                 }
-//                 JoinStrategy::Left => {
-//                     // advance left and see if we can match
-//                     if left.advance() {
-//                         while self.right_index + 1 < right.len()
-//                             && right[self.right_index].item_list[0].0 < left.key
-//                         {
-//                             self.right_index += 1;
-//                         }
-//                         // after this the key is guaranteed to be equal to the left key or bigger
-//                         // so if the keys match that will be fine for copy in, otherwise this will be skipped
-//                         // if the key already equal or bigger, it was not advanced
-//                         self.key = left.key;
-//                         true
-//                     } else {
-//                         self.right_index = right.len();
-//                         false
-//                     }
-//                 }
-//                 JoinStrategy::Right => {
-//                     if self.right_index + 1 >= right.len() {
-//                         self.right_index = right.len();
-//                         return false;
-//                     }
-//                     self.right_index += 1;
-//                     self.key = right[self.right_index].item_list[0].0;
-//                     while self.key > left.key {
-//                         if !left.advance() {
-//                             break;
-//                         }
-//                     }
-//                     true
-//                 }
-//                 JoinStrategy::Outer => {
-//                     let current_self_key = right[self.right_index].item_list[0].0;
-//                     let right_can_be_advanced = self.right_index + 1 < right.len();
-//                     // check if one of the already known keys is bigger, if so we know we can adavance
-//                     if self.key < left.key {
-//                         // last key was set from right, since left is bigger
-//                         debug_assert_eq!(self.key, current_self_key);
-//                         // if right can be advance it should be advanced, otherwise just set key to left one
-//                         if right_can_be_advanced {
-//                             self.right_index += 1;
-//                             // new right might still be smaller than left key
-//                             self.key = u32::min(right[self.right_index].item_list[0].0, left.key);
-//                         } else {
-//                             self.key = left.key;
-//                         }
-//                         true
-//                     } else if self.key < current_self_key {
-//                         // the last key was set from left, since right is bigger
-//                         debug_assert_eq!(self.key, left.key);
-//                         // if left can be adnvanced it should be, if not move
-//                         if left.advance() {
-//                             // new left key might still be smaller than right
-//                             self.key = u32::min(right[self.right_index].item_list[0].0, left.key);
-//                         } else {
-//                             //  left did not advance, so set key to current right key
-//                             self.key = current_self_key;
-//                         }
-//                         true
-//                     } else if self.key == left.key && self.key == current_self_key {
-//                         // both keys are the same, so advance any that are possible to advance and take new key from there
-//                         let left_advance_success = left.advance();
-//                         if right_can_be_advanced {
-//                             self.right_index += 1;
-//                         }
-//                         match (right_can_be_advanced, left_advance_success) {
-//                             (true, true) => {
-//                                 self.key =
-//                                     u32::min(right[self.right_index].item_list[0].0, left.key);
-//                                 true
-//                             }
-//                             (true, false) => {
-//                                 self.key = right[self.right_index].item_list[0].0;
-//                                 true
-//                             }
-//                             (false, true) => {
-//                                 self.key = left.key;
-//                                 true
-//                             }
-//                             (false, false) => {
-//                                 self.right_index = right.len();
-//                                 false
-//                             }
-//                         }
-//                     } else {
-//                         // the key is already set to the bigger of the two current keys, try to advance that one
-//                         if current_self_key == left.key {
-//                             let did_advance = left.advance();
-//                             self.key = left.key;
-//                             did_advance
-//                         } else {
-//                             if right_can_be_advanced {
-//                                 self.right_index += 1;
-//                                 self.key = right[self.right_index].item_list[0].0;
-//                             }
-//                             right_can_be_advanced
-//                         }
-//                     }
-//                 }
-//                 JoinStrategy::Cross => {
-//                     if self.right_index + 1 < right.len() {
-//                         self.right_index += 1;
-//                         self.key = right[self.right_index].item_list[0].0;
-//                         true
-//                     } else if left.advance() {
-//                         self.right_index = 0;
-//                         self.key = right[0].item_list[0].0;
-//                         true
-//                     } else {
-//                         // set right index to len so we can't accidentally copy something
-//                         self.right_index = right.len();
-//                         false
-//                     }
-//                 }
-//             }
-//         } else {
-//             if self.right_index + 1 >= right.len() {
-//                 self.right_index = right.len();
-//                 false
-//             } else {
-//                 // advancing only makes sense for certain modes here
-//                 if self.mode == JoinStrategy::Right
-//                     || self.mode == JoinStrategy::Outer
-//                     || self.mode == JoinStrategy::Cross
-//                 {
-//                     self.right_index += 1;
-//                     self.key = right[self.right_index].item_list[0].0;
-//                     true
-//                 } else {
-//                     panic!("Should never have join iterator with left or inner that has None for the left value");
-//                 }
-//             }
-//         }
-//     }
-// }
 
 //=======
 // TESTS
@@ -968,7 +673,7 @@ fn join_it_inner_test() {
     let join_order = vec![0, 1];
     let join_strategies = vec![JoinStrategy::Inner];
 
-    let sharding = get_sharding(sets, join_order, join_strategies);
+    let sharding = get_sharding(sets, join_order, join_strategies, 0);
     let expected = vec![
         vec![Some(vec![(0, 1)]), Some(vec![(0, 1)])],
         vec![Some(vec![(1, 2)]), Some(vec![(1, 0), (1, 2)])],
@@ -988,7 +693,7 @@ fn join_it_left_test() {
     let join_order = vec![0, 1];
     let join_strategies = vec![JoinStrategy::Left];
 
-    let sharding = get_sharding(sets, join_order, join_strategies);
+    let sharding = get_sharding(sets, join_order, join_strategies, 0);
     let expected = vec![
         vec![Some(vec![(0, 0)]), Some(vec![(0, 2)])],
         vec![Some(vec![(1, 1)]), Some(vec![(1, 1), (1, 3)])],
@@ -1009,7 +714,7 @@ fn join_it_right_test() {
     let join_order = vec![0, 1];
     let join_strategies = vec![JoinStrategy::Right];
 
-    let sharding = get_sharding(sets, join_order, join_strategies);
+    let sharding = get_sharding(sets, join_order, join_strategies, 0);
     let expected = vec![
         vec![Some(vec![(0, 2)]), Some(vec![(0, 0)])],
         vec![Some(vec![(1, 1), (1, 3)]), Some(vec![(1, 1)])],
@@ -1030,7 +735,7 @@ fn join_it_outer_test() {
     let join_order = vec![0, 1];
     let join_strategies = vec![JoinStrategy::Outer];
 
-    let sharding = get_sharding(sets, join_order, join_strategies);
+    let sharding = get_sharding(sets, join_order, join_strategies, 0);
     let expected = vec![
         vec![Some(vec![(0, 0)]), Some(vec![(0, 2)])],
         vec![Some(vec![(1, 1)]), Some(vec![(1, 1), (1, 3)])],
@@ -1052,7 +757,7 @@ fn join_it_cross_test() {
     let join_order = vec![0, 1];
     let join_strategies = vec![JoinStrategy::Cross];
 
-    let sharding = get_sharding(sets, join_order, join_strategies);
+    let sharding = get_sharding(sets, join_order, join_strategies, 0);
     let expected = vec![
         vec![Some(vec![(0, 0)]), Some(vec![(0, 2)])],
         vec![Some(vec![(0, 0)]), Some(vec![(1, 1), (1, 3)])],
@@ -1079,7 +784,7 @@ fn join_it_order_test() {
     let join_order = vec![1, 0];
     let join_strategies = vec![JoinStrategy::Left];
 
-    let sharding = get_sharding(sets, join_order, join_strategies);
+    let sharding = get_sharding(sets, join_order, join_strategies, 0);
     let expected = vec![
         vec![Some(vec![(0, 2)]), Some(vec![(0, 0)])],
         vec![Some(vec![(1, 1), (1, 3)]), Some(vec![(1, 1)])],
@@ -1118,7 +823,7 @@ fn join_it_chain_test() {
         JoinStrategy::Outer,
     ];
 
-    let sharding = get_sharding(sets, join_order, join_strategies);
+    let sharding = get_sharding(sets, join_order, join_strategies, 0);
     let expected = vec![
         vec![Some(vec![(1, 0)]), None, None, None],
         vec![None, Some(vec![(2, 0)]), None, None],
@@ -1153,6 +858,75 @@ fn join_it_chain_test() {
             Some(vec![(1234, 2)]),
             Some(vec![(1234, 3)]),
             Some(vec![(1234, 4)]),
+        ],
+    ];
+
+    print_sharding(&sharding);
+    check_sharding(sharding, expected);
+}
+
+#[test]
+fn join_it_any_simple_test() {
+    let sets = vec![Some((
+        ShardingMode::AnyEach,
+        create_dummy_set(vec![0, 1, 2, 3]),
+    ))];
+
+    let join_order = vec![0];
+    let join_strategies = vec![];
+
+    let sharding = get_sharding(sets, join_order, join_strategies, 2);
+    let expected = vec![
+        vec![Some(vec![(0, 0), (1, 1)])],
+        vec![Some(vec![(2, 2), (3, 3)])],
+    ];
+
+    print_sharding(&sharding);
+    check_sharding(sharding, expected);
+}
+
+#[test]
+fn join_it_any_joined_keys_test() {
+    let sets = vec![
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 2, 3, 5]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 3, 4, 5]))),
+    ];
+
+    let join_order = vec![0, 1];
+    let join_strategies = vec![JoinStrategy::Inner];
+
+    let sharding = get_sharding(sets, join_order, join_strategies, 2);
+    let expected = vec![
+        vec![Some(vec![(0, 0), (2, 2)]), Some(vec![(0, 0), (2, 1)])],
+        vec![Some(vec![(3, 3), (5, 4)]), Some(vec![(3, 2), (5, 4)])],
+    ];
+
+    print_sharding(&sharding);
+    check_sharding(sharding, expected);
+}
+
+#[test]
+fn join_it_any_chain_test() {
+    let sets = vec![
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0, 0]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 2, 3, 5]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 3, 4, 5]))),
+    ];
+
+    let join_order = vec![1, 2, 0];
+    let join_strategies = vec![JoinStrategy::Inner];
+
+    let sharding = get_sharding(sets, join_order, join_strategies, 2);
+    let expected = vec![
+        vec![
+            Some(vec![(0, 0), (0, 1), (0, 2)]),
+            Some(vec![(0, 0), (2, 2)]),
+            Some(vec![(0, 0), (2, 1)]),
+        ],
+        vec![
+            Some(vec![(0, 0), (0, 1), (0, 2)]),
+            Some(vec![(3, 3), (5, 4)]),
+            Some(vec![(3, 2), (5, 4)]),
         ],
     ];
 

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -256,6 +256,7 @@ fn compute_any_parallelism(
                     curr_join_keys.clear();
                 }
             }
+            continue;
         }
         let (sharding, set) = sets[*set_index].as_ref().unwrap();
         match *sharding {

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -1,13 +1,11 @@
-use crate::memory_domain::{Context, ContextTrait};
+use crate::{
+    composition::join_iterator::JoinIterator,
+    memory_domain::{Context, ContextTrait},
+};
 use dandelion_commons::{
     err_dandelion, DandelionError, DandelionResult, DispatcherError, FunctionId,
 };
-use std::{
-    cmp,
-    collections::{BTreeMap, HashMap, HashSet},
-    sync::Arc,
-    vec,
-};
+use std::{cmp, collections::BTreeMap, sync::Arc, vec};
 
 #[cfg(test)]
 use crate::memory_domain::read_only::ReadOnlyContext;
@@ -112,17 +110,6 @@ impl CompositionSet {
         self.item_list.len()
     }
 
-    pub fn sharded_len(&self, mode: ShardingMode) -> usize {
-        match mode {
-            ShardingMode::Each => self.len(),
-            ShardingMode::Key => self
-                .item_list
-                .chunk_by(|(key_a, _, _), (key_b, _, _)| key_a == key_b)
-                .count(),
-            ShardingMode::All | _ => 1, // any are resource dependent so return 1
-        }
-    }
-
     pub fn get_set_idx(&self) -> usize {
         self.set_index
     }
@@ -153,22 +140,6 @@ impl CompositionSet {
         self.item_list.extend(item_list.into_iter());
         self.item_list.sort_unstable_by_key(|a| a.0);
         return Ok(());
-    }
-
-    pub fn combine_keys_with_set(&self, other: &mut HashSet<u32>, intersect: bool) {
-        if intersect {
-            let mut new_set = HashSet::new();
-            for (key, _, _) in self.item_list.iter() {
-                if other.contains(key) {
-                    new_set.insert(*key);
-                }
-            }
-            *other = new_set;
-        } else {
-            for (key, _, _) in self.item_list.iter() {
-                other.insert(*key);
-            }
-        }
     }
 }
 
@@ -220,203 +191,6 @@ impl<'origin> IntoIterator for &'origin CompositionSet {
     }
 }
 
-// NOTE: assumes at least one element
-fn compute_any_parallelism(
-    sets: &Vec<Option<(ShardingMode, CompositionSet)>>,
-    join_order: &Vec<usize>,
-    join_strategies: &Vec<JoinStrategy>,
-    target_parallelism: usize,
-) -> HashMap<usize, usize> {
-    let mut any_set_parallelism: HashMap<usize, usize> = HashMap::new();
-    if target_parallelism == 0 {
-        return any_set_parallelism;
-    }
-
-    debug_assert!(sets.len() > 0);
-    let mut curr_join_keys: HashSet<u32> = HashSet::new();
-    let mut curr_any_group: Option<Vec<usize>> = None;
-    let mut any_groups: Vec<(Vec<usize>, usize)> = Vec::new();
-    let mut fixed_parallelism = 1;
-    for (i, set_index) in join_order.iter().enumerate() {
-        let strategy = if i > 0 {
-            join_strategies[i - 1]
-        } else {
-            JoinStrategy::Cross
-        };
-        if sets[*set_index].is_none() {
-            match strategy {
-                JoinStrategy::Left | JoinStrategy::Outer => {
-                    // for left and outer joins this set may be none
-                    if let Some(idx_list) = curr_any_group.as_mut() {
-                        idx_list.push(*set_index);
-                    }
-                }
-                _ => {
-                    curr_any_group = None;
-                    curr_join_keys.clear();
-                }
-            }
-            continue;
-        }
-        let (sharding, set) = sets[*set_index].as_ref().unwrap();
-        match *sharding {
-            ShardingMode::AnyEach => {
-                // push current group or add parallelism of current join
-                if let Some(idx_list) = curr_any_group.take() {
-                    any_groups.push((idx_list, curr_join_keys.len()));
-                    curr_join_keys.clear();
-                } else if !curr_join_keys.is_empty() {
-                    fixed_parallelism *= curr_join_keys.len();
-                    curr_join_keys.clear();
-                }
-
-                // push this group (each cannot be joined)
-                any_groups.push((vec![*set_index], set.len()));
-            }
-            ShardingMode::AnyKey => {
-                match strategy {
-                    JoinStrategy::Left => {
-                        // only add the set index to the list
-                        if let Some(idx_list) = curr_any_group.as_mut() {
-                            idx_list.push(*set_index);
-                        }
-                    }
-                    JoinStrategy::Right => {
-                        // only use this set's keys
-                        curr_join_keys.clear();
-                        set.combine_keys_with_set(&mut curr_join_keys, false);
-                        if let Some(idx_list) = curr_any_group.as_mut() {
-                            idx_list.push(*set_index);
-                        } else {
-                            curr_any_group = Some(vec![*set_index]);
-                        }
-                    }
-                    JoinStrategy::Inner => {
-                        // use key intersection
-                        set.combine_keys_with_set(&mut curr_join_keys, true);
-                        if let Some(idx_list) = curr_any_group.as_mut() {
-                            idx_list.push(*set_index);
-                        }
-                    }
-                    JoinStrategy::Outer => {
-                        // use key union
-                        set.combine_keys_with_set(&mut curr_join_keys, false);
-                        if let Some(idx_list) = curr_any_group.as_mut() {
-                            idx_list.push(*set_index);
-                        } else {
-                            curr_any_group = Some(vec![*set_index]);
-                        }
-                    }
-                    JoinStrategy::Cross => {
-                        // push current group or add parallelism of current join
-                        if let Some(idx_list) = curr_any_group.take() {
-                            any_groups.push((idx_list, curr_join_keys.len()));
-                            curr_join_keys.clear();
-                        } else if !curr_join_keys.is_empty() {
-                            fixed_parallelism *= curr_join_keys.len();
-                            curr_join_keys.clear();
-                        }
-                        // create next group
-                        curr_join_keys.clear();
-                        set.combine_keys_with_set(&mut curr_join_keys, false);
-                        curr_any_group = Some(vec![*set_index]);
-                    }
-                }
-            }
-            ShardingMode::Key => {
-                // if an AnyKey is joined with a normal Key it becomes invalid except for cross joins
-                if strategy == JoinStrategy::Cross {
-                    if let Some(idx_list) = curr_any_group.take() {
-                        any_groups.push((idx_list, curr_join_keys.len()));
-                    }
-                    curr_join_keys.clear();
-                } else {
-                    curr_any_group = None;
-                    if strategy == JoinStrategy::Right {
-                        curr_join_keys.clear(); // -> for right we only care about this set's keys
-                    }
-                    if strategy != JoinStrategy::Left {
-                        set.combine_keys_with_set(
-                            &mut curr_join_keys,
-                            strategy != JoinStrategy::Outer,
-                        );
-                    }
-                }
-            }
-            _ => {
-                // push current group or add parallelism of current join
-                if let Some(idx_list) = curr_any_group.take() {
-                    any_groups.push((idx_list, curr_join_keys.len()));
-                    curr_join_keys.clear();
-                } else if !curr_join_keys.is_empty() {
-                    fixed_parallelism *= curr_join_keys.len();
-                    curr_join_keys.clear();
-                }
-                // add parallelism of this set
-                fixed_parallelism *= set.sharded_len(*sharding);
-            }
-        }
-    }
-
-    // push current group or add parallelism of current join
-    if let Some(idx_list) = curr_any_group.take() {
-        any_groups.push((idx_list, curr_join_keys.len()));
-        curr_join_keys.clear();
-    } else if !curr_join_keys.is_empty() {
-        fixed_parallelism *= curr_join_keys.len();
-        curr_join_keys.clear();
-    }
-
-    log::trace!(
-        "Found fixed_parallelism: {} (target_parallelism: {})",
-        fixed_parallelism,
-        target_parallelism
-    );
-
-    // find the best suitable any set(s) and determine their parallelism
-    if fixed_parallelism < target_parallelism && !any_groups.is_empty() {
-        let mut leftover_parallelism = target_parallelism / fixed_parallelism;
-        loop {
-            let mut best_idx = 0;
-            let mut best_dist = 0.0;
-            for (i, (_, max_p)) in any_groups.iter().enumerate() {
-                let remainder = max_p % leftover_parallelism;
-                if remainder == 0 {
-                    best_idx = i;
-                    best_dist = 0.0;
-                    break;
-                }
-                let dist = (remainder) as f64 / (*max_p) as f64;
-                if best_dist == 0.0 || dist < best_dist {
-                    best_idx = i;
-                    best_dist = dist;
-                }
-            }
-
-            // if the best set has fewer elements than the leftover parallelization we continue and
-            // check if we can find another set to parallelize over in addition to the found one
-            if best_dist >= 1.0 {
-                for set_idx in any_groups[best_idx].0.iter() {
-                    any_set_parallelism.insert(*set_idx, any_groups[best_idx].1);
-                }
-                leftover_parallelism /= any_groups[best_idx].1;
-                if leftover_parallelism <= 1 {
-                    break;
-                }
-            } else {
-                for set_idx in any_groups[best_idx].0.iter() {
-                    any_set_parallelism.insert(
-                        *set_idx,
-                        cmp::min(leftover_parallelism, any_groups[best_idx].1),
-                    );
-                }
-                break;
-            }
-        }
-    }
-    any_set_parallelism
-}
-
 /// Computes the sharding for the given sets following the given join order and join strategies.
 /// The `join_strategies` vector is expected to be of size <= `join_order.len() - 1`.
 /// The function tries to produce an output vector of size `target_parallelism` if possible grouping
@@ -446,14 +220,50 @@ pub fn get_sharding(
     }
     join_strategies.resize(set_num - 1, JoinStrategy::Cross);
 
-    // compute the parallelism of the any sets
-    let any_set_parallelism =
-        compute_any_parallelism(&sets, &join_order, &join_strategies, target_parallelism);
-    log::trace!("Computed any_set_parallelism: {:?}", any_set_parallelism);
-
-    // create the iterators later used to generate the final sharding
-    let mut join_iter = None;
+    // first create the iterators for any keyed shardings
+    let mut key_join_iter = None;
+    let mut fixed_parallelism = 1;
+    let mut join_group_key_set: Vec<u32> = vec![];
     let mut i = 0;
+    while i < join_order.len() {
+        let set_idx = join_order[i];
+        if let Some((sharding, set)) = sets[set_idx].take() {
+            if sharding != ShardingMode::Key {
+                if join_group_key_set.len() > 0 {
+                    fixed_parallelism *= join_group_key_set.len();
+                    join_group_key_set.clear();
+                }
+                sets[set_idx] = Some((sharding, set)); // put back into sets
+                break; // continue building all other iterators in the second loop
+            }
+
+            let strategy = if i > 0 {
+                join_strategies[i - 1]
+            } else {
+                JoinStrategy::Cross
+            };
+
+            if strategy == JoinStrategy::Cross {
+                if join_group_key_set.len() > 0 {
+                    fixed_parallelism *= join_group_key_set.len();
+                    join_group_key_set.clear();
+                }
+            }
+
+            key_join_iter = join_iterator::SetKeyIterator::new(
+                key_join_iter,
+                set,
+                strategy,
+                set_idx,
+                &mut join_group_key_set,
+            );
+        }
+        i += 1;
+    }
+
+    // second create the iterators for all remaining shardings
+    let mut any_parallelisms: Vec<(usize, usize)> = Vec::new(); // vec of (max parallelism, chosen parallelism)
+    let mut join_iter = key_join_iter.map(|i| i as Box<dyn JoinIterator>);
     while i < join_order.len() {
         let set_idx = join_order[i];
         if let Some((sharding, set)) = sets[set_idx].take() {
@@ -462,73 +272,112 @@ pub fn get_sharding(
                     join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
                 }
                 ShardingMode::Each => {
-                    join_iter = join_iterator::SetEachIterator::new(join_iter, set, set_idx);
-                }
-                ShardingMode::Key => {
-                    let strategy = if i > 0 {
-                        join_strategies[i - 1]
-                    } else {
-                        JoinStrategy::Cross
-                    };
-                    join_iter =
-                        join_iterator::SetKeyIterator::new(join_iter, set, strategy, set_idx);
+                    let parallelism;
+                    (join_iter, parallelism) =
+                        join_iterator::SetEachIterator::new(join_iter, set, set_idx);
+                    fixed_parallelism *= parallelism;
                 }
                 ShardingMode::AnyEach => {
-                    if let Some(num_groups) = any_set_parallelism.get(&set_idx) {
-                        join_iter = join_iterator::AnyIterator::new(
-                            join_iter,
-                            vec![set],
-                            vec![],
-                            vec![set_idx],
-                            *num_groups,
-                            sharding,
-                        );
-                    } else {
-                        // TODO: do we want maximum parallelism in this case or zero parallelism?
-                        // if we got no specific parallelism for this set we assume parallelism is 1
-                        join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
+                    let (any_join_iter, max_parallelism) = join_iterator::AnyIterator::new(
+                        join_iter,
+                        vec![set],
+                        vec![],
+                        vec![set_idx],
+                        sharding,
+                    );
+                    if any_join_iter.is_some() {
+                        any_parallelisms.push((max_parallelism, 1));
                     }
+                    join_iter = any_join_iter.map(|i| i as Box<dyn JoinIterator>);
                 }
                 ShardingMode::AnyKey => {
-                    if let Some(num_groups) = any_set_parallelism.get(&set_idx) {
-                        // get all sets that are joined together (i.e. find the next cross join)
-                        let mut joined_sets = vec![set];
-                        let mut joined_set_idcs = vec![set_idx];
-                        let mut joined_strategies = vec![];
-                        while i + 1 < join_order.len() {
-                            let next_strategy = join_strategies[i];
-                            if next_strategy != JoinStrategy::Cross {
-                                let next_set_idx = join_order[i + 1];
-                                if let Some((_, set)) = sets[next_set_idx].take() {
-                                    joined_sets.push(set);
-                                    joined_set_idcs.push(next_set_idx);
-                                    joined_strategies.push(next_strategy);
-                                }
-                                // NOTE: if the set is none we just skip it -> this allows for empty
-                                //       optional sets
-                                i += 1;
-                            } else {
-                                // a cross join breaks the chain
-                                break;
+                    // get all sets that are joined together (i.e. find the next cross join)
+                    let mut joined_sets = vec![set];
+                    let mut joined_set_idcs = vec![set_idx];
+                    let mut joined_strategies = vec![];
+                    while i + 1 < join_order.len() {
+                        let next_strategy = join_strategies[i];
+                        if next_strategy != JoinStrategy::Cross {
+                            let next_set_idx = join_order[i + 1];
+                            // if the set is none we just skip it -> this allows for empty optional sets
+                            if let Some((_, set)) = sets[next_set_idx].take() {
+                                joined_sets.push(set);
+                                joined_set_idcs.push(next_set_idx);
+                                joined_strategies.push(next_strategy);
                             }
+                            i += 1;
+                        } else {
+                            // a cross join breaks the chain
+                            break;
                         }
-                        join_iter = join_iterator::AnyIterator::new(
-                            join_iter,
-                            joined_sets,
-                            joined_strategies,
-                            joined_set_idcs,
-                            *num_groups,
-                            sharding,
-                        );
-                    } else {
-                        // TODO: do we want maximum parallelism in this case or zero parallelism?
-                        // if we got no specific parallelism for this set we assume parallelism is 1
-                        join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
                     }
+
+                    let (any_join_iter, max_parallelism) = join_iterator::AnyIterator::new(
+                        join_iter,
+                        joined_sets,
+                        joined_strategies,
+                        joined_set_idcs,
+                        sharding,
+                    );
+                    if any_join_iter.is_some() {
+                        any_parallelisms.push((max_parallelism, 1));
+                    }
+                    join_iter = any_join_iter.map(|i| i as Box<dyn JoinIterator>);
+                }
+                ShardingMode::Key => {
+                    panic!("Expecting key shardings to preceed all other shardings.");
                 }
             }
         }
         i += 1;
+    }
+
+    // compute the parallelism for the any shardings
+    if fixed_parallelism < target_parallelism && !any_parallelisms.is_empty() {
+        let mut leftover_parallelism = target_parallelism / fixed_parallelism;
+        loop {
+            // find the best suitable set to parallelize over
+            let mut best_idx = 0;
+            let mut best_dist = 0.0;
+            for (i, (max_p, chosen_p)) in any_parallelisms.iter().enumerate() {
+                // check that we have not yet assigned a parallelism to this any set
+                if *chosen_p == 1 {
+                    let remainder = max_p % leftover_parallelism;
+                    if remainder == 0 {
+                        best_idx = i;
+                        best_dist = 0.0;
+                        break;
+                    }
+                    let dist = (remainder) as f64 / (*max_p) as f64;
+                    if best_dist == 0.0 || dist < best_dist {
+                        best_idx = i;
+                        best_dist = dist;
+                    }
+                }
+            }
+
+            // if the best set has fewer elements than the leftover parallelization we continue and
+            // check if we can find another set to parallelize over in addition to the found one
+            if best_dist >= 1.0 {
+                let max_parallelism = any_parallelisms[best_idx].0;
+                any_parallelisms[best_idx].1 = max_parallelism;
+                leftover_parallelism /= max_parallelism;
+                if leftover_parallelism <= 1 {
+                    break;
+                }
+            } else {
+                if any_parallelisms[best_idx].1 == 1 {
+                    let chosen_parallelism =
+                        cmp::min(leftover_parallelism, any_parallelisms[best_idx].0);
+                    any_parallelisms[best_idx].1 = chosen_parallelism;
+                }
+                break;
+            }
+        }
+
+        if let Some(iter) = join_iter.as_mut() {
+            iter.reduce_any_parallelism(any_parallelisms);
+        }
     }
 
     // generate the sharding sets
@@ -921,7 +770,7 @@ fn join_it_any_chain_test() {
 }
 
 #[test]
-fn any_parallelism_test_1() {
+fn join_it_any_chain_test_1() {
     let sets = vec![
         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1]))),
         Some((
@@ -932,189 +781,195 @@ fn any_parallelism_test_1() {
     ];
 
     let join_order = vec![0, 1, 2];
-    let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
-
-    let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
-    assert_eq!(any_set_parallelism_6.len(), 1);
-    assert!(any_set_parallelism_6.contains_key(&1));
-    assert_eq!(any_set_parallelism_6[&1], 6);
-
-    let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
-    assert_eq!(any_set_parallelism_3.len(), 1);
-    assert!(any_set_parallelism_3.contains_key(&1));
-    assert_eq!(any_set_parallelism_3[&1], 3);
-
-    let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
-    assert_eq!(any_set_parallelism_4.len(), 1);
-    assert!(any_set_parallelism_4.contains_key(&2));
-    assert_eq!(any_set_parallelism_4[&2], 4);
-}
-
-#[test]
-fn any_parallelism_test_2() {
-    let sets = vec![
-        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1, 2]))),
-        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1]))),
-    ];
-
-    let join_order = vec![0, 1];
-    let join_strategies = vec![JoinStrategy::Cross];
-
-    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-    assert_eq!(any_set_parallelism_2.len(), 1);
-    assert!(any_set_parallelism_2.contains_key(&1));
-    assert_eq!(any_set_parallelism_2[&1], 2);
-
-    let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
-    assert_eq!(any_set_parallelism_3.len(), 1);
-    assert!(any_set_parallelism_3.contains_key(&0));
-    assert_eq!(any_set_parallelism_3[&0], 3);
-
-    let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
-    assert_eq!(any_set_parallelism_6.len(), 2);
-    assert!(any_set_parallelism_6.contains_key(&0));
-    assert!(any_set_parallelism_6.contains_key(&1));
-    assert_eq!(any_set_parallelism_6[&0], 3);
-    assert_eq!(any_set_parallelism_6[&1], 2);
-}
-
-#[test]
-fn any_parallelism_test_3() {
-    let sets = vec![
-        Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
-        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0, 0]))),
-        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
-    ];
-
-    let join_order = vec![0, 1, 2];
-    let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
-
-    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-    assert_eq!(any_set_parallelism_2.len(), 0);
-
-    let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
-    assert_eq!(any_set_parallelism_4.len(), 1);
-    assert!(any_set_parallelism_4.contains_key(&2));
-    assert_eq!(any_set_parallelism_4[&2], 2);
-
-    let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
-    assert_eq!(any_set_parallelism_6.len(), 1);
-    assert!(any_set_parallelism_6.contains_key(&1));
-    assert_eq!(any_set_parallelism_6[&1], 3);
-}
-
-#[test]
-fn any_parallelism_test_4() {
-    let sets = vec![
-        Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
-        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
-        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1, 4]))),
-    ];
-
-    let join_order = vec![0, 1, 2];
-
-    let join_strategies_inner = vec![JoinStrategy::Cross, JoinStrategy::Inner];
-    let any_set_parallelism_inner =
-        compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
-    assert_eq!(any_set_parallelism_inner.len(), 2);
-    assert!(any_set_parallelism_inner.contains_key(&1));
-    assert!(any_set_parallelism_inner.contains_key(&2));
-    assert_eq!(any_set_parallelism_inner[&1], 2);
-    assert_eq!(any_set_parallelism_inner[&2], 2);
-
-    let join_strategies_left = vec![JoinStrategy::Cross, JoinStrategy::Left];
-    let any_set_parallelism_left =
-        compute_any_parallelism(&sets, &join_order, &join_strategies_left, 10);
-    assert_eq!(any_set_parallelism_left.len(), 2);
-    assert!(any_set_parallelism_left.contains_key(&1));
-    assert!(any_set_parallelism_left.contains_key(&2));
-    assert_eq!(any_set_parallelism_left[&1], 4);
-    assert_eq!(any_set_parallelism_left[&2], 4);
-
-    let join_strategies_right = vec![JoinStrategy::Cross, JoinStrategy::Right];
-    let any_set_parallelism_right =
-        compute_any_parallelism(&sets, &join_order, &join_strategies_right, 10);
-    assert_eq!(any_set_parallelism_right.len(), 2);
-    assert!(any_set_parallelism_right.contains_key(&1));
-    assert!(any_set_parallelism_right.contains_key(&2));
-    assert_eq!(any_set_parallelism_right[&1], 3);
-    assert_eq!(any_set_parallelism_right[&2], 3);
-
-    let join_strategies_outer = vec![JoinStrategy::Cross, JoinStrategy::Outer];
-    let any_set_parallelism_outer =
-        compute_any_parallelism(&sets, &join_order, &join_strategies_outer, 10);
-    assert_eq!(any_set_parallelism_outer.len(), 2);
-    assert!(any_set_parallelism_outer.contains_key(&1));
-    assert!(any_set_parallelism_outer.contains_key(&2));
-    assert_eq!(any_set_parallelism_outer[&1], 5);
-    assert_eq!(any_set_parallelism_outer[&2], 5);
-}
-
-#[test]
-fn any_parallelism_test_5() {
-    let sets = vec![
-        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
-        Some((ShardingMode::Key, create_dummy_set(vec![0, 1, 1, 4]))),
-    ];
-
-    let join_order = vec![0, 1];
-    let join_strategies_inner = vec![JoinStrategy::Inner];
-
-    // if an AnyKey and a Key are joined with a strategy other than cross it is no longer a valid
-    // any set -> the output should be empty
-    let any_set_parallelism_inner =
-        compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
-    assert_eq!(any_set_parallelism_inner.len(), 0);
-}
-
-#[test]
-fn any_parallelism_test_6() {
-    let sets = vec![Some((
-        ShardingMode::AnyKey,
-        create_dummy_set(vec![0, 2, 0, 1, 3]),
-    ))];
-
-    let join_order = vec![0];
     let join_strategies = vec![];
 
-    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-    assert_eq!(any_set_parallelism_2.len(), 1);
-    assert!(any_set_parallelism_2.contains_key(&0));
-    assert_eq!(any_set_parallelism_2[&0], 2);
+    let sharding_6 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 6);
+    assert_eq!(sharding_6.len(), 6); // <- should get 6 shardings
+    assert_eq!(sharding_6[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_6[0][0].as_ref().unwrap().len(), 2);
+    assert_eq!(sharding_6[0][1].as_ref().unwrap().len(), 1); // <- parallelized set
+    assert_eq!(sharding_6[0][2].as_ref().unwrap().len(), 4);
 
-    let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
-    assert_eq!(any_set_parallelism_4.len(), 1);
-    assert!(any_set_parallelism_4.contains_key(&0));
-    assert_eq!(any_set_parallelism_4[&0], 4);
+    let sharding_3 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 3);
+    assert_eq!(sharding_3.len(), 3); // <- should get 3 shardings
+    assert_eq!(sharding_3[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_3[0][0].as_ref().unwrap().len(), 2);
+    assert_eq!(sharding_3[0][1].as_ref().unwrap().len(), 2); // <- parallelized set
+    assert_eq!(sharding_3[0][2].as_ref().unwrap().len(), 4);
+
+    let sharding_4 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 4);
+    assert_eq!(sharding_4.len(), 4); // <- should get 4 shardings
+    assert_eq!(sharding_4[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_4[0][0].as_ref().unwrap().len(), 2);
+    assert_eq!(sharding_4[0][1].as_ref().unwrap().len(), 6);
+    assert_eq!(sharding_4[0][2].as_ref().unwrap().len(), 1); // <- parallelized set
 }
 
-#[test]
-fn any_parallelism_test_7() {
-    let sets = vec![
-        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 4]))),
-        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 3]))),
-        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
-        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0]))),
-    ];
+// #[test]
+// fn any_parallelism_test_2() {
+//     let sets = vec![
+//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1, 2]))),
+//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1]))),
+//     ];
 
-    let join_order = vec![1, 2, 0, 3];
-    let join_strategies = vec![
-        JoinStrategy::Inner,
-        JoinStrategy::Right,
-        JoinStrategy::Cross,
-    ];
+//     let join_order = vec![0, 1];
+//     let join_strategies = vec![JoinStrategy::Cross];
 
-    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-    assert_eq!(any_set_parallelism_2.len(), 1);
-    assert!(any_set_parallelism_2.contains_key(&3));
-    assert_eq!(any_set_parallelism_2[&3], 2);
+//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+//     assert_eq!(any_set_parallelism_2.len(), 1);
+//     assert!(any_set_parallelism_2.contains_key(&1));
+//     assert_eq!(any_set_parallelism_2[&1], 2);
 
-    let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
-    assert_eq!(any_set_parallelism_3.len(), 3);
-    assert!(any_set_parallelism_3.contains_key(&0));
-    assert!(any_set_parallelism_3.contains_key(&1));
-    assert!(any_set_parallelism_3.contains_key(&2));
-    assert_eq!(any_set_parallelism_3[&0], 3);
-    assert_eq!(any_set_parallelism_3[&1], 3);
-    assert_eq!(any_set_parallelism_3[&2], 3);
-}
+//     let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
+//     assert_eq!(any_set_parallelism_3.len(), 1);
+//     assert!(any_set_parallelism_3.contains_key(&0));
+//     assert_eq!(any_set_parallelism_3[&0], 3);
+
+//     let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
+//     assert_eq!(any_set_parallelism_6.len(), 2);
+//     assert!(any_set_parallelism_6.contains_key(&0));
+//     assert!(any_set_parallelism_6.contains_key(&1));
+//     assert_eq!(any_set_parallelism_6[&0], 3);
+//     assert_eq!(any_set_parallelism_6[&1], 2);
+// }
+
+// #[test]
+// fn any_parallelism_test_3() {
+//     let sets = vec![
+//         Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
+//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0, 0]))),
+//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
+//     ];
+
+//     let join_order = vec![0, 1, 2];
+//     let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
+
+//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+//     assert_eq!(any_set_parallelism_2.len(), 0);
+
+//     let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
+//     assert_eq!(any_set_parallelism_4.len(), 1);
+//     assert!(any_set_parallelism_4.contains_key(&2));
+//     assert_eq!(any_set_parallelism_4[&2], 2);
+
+//     let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
+//     assert_eq!(any_set_parallelism_6.len(), 1);
+//     assert!(any_set_parallelism_6.contains_key(&1));
+//     assert_eq!(any_set_parallelism_6[&1], 3);
+// }
+
+// #[test]
+// fn any_parallelism_test_4() {
+//     let sets = vec![
+//         Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
+//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
+//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1, 4]))),
+//     ];
+
+//     let join_order = vec![0, 1, 2];
+
+//     let join_strategies_inner = vec![JoinStrategy::Cross, JoinStrategy::Inner];
+//     let any_set_parallelism_inner =
+//         compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
+//     assert_eq!(any_set_parallelism_inner.len(), 2);
+//     assert!(any_set_parallelism_inner.contains_key(&1));
+//     assert!(any_set_parallelism_inner.contains_key(&2));
+//     assert_eq!(any_set_parallelism_inner[&1], 2);
+//     assert_eq!(any_set_parallelism_inner[&2], 2);
+
+//     let join_strategies_left = vec![JoinStrategy::Cross, JoinStrategy::Left];
+//     let any_set_parallelism_left =
+//         compute_any_parallelism(&sets, &join_order, &join_strategies_left, 10);
+//     assert_eq!(any_set_parallelism_left.len(), 2);
+//     assert!(any_set_parallelism_left.contains_key(&1));
+//     assert!(any_set_parallelism_left.contains_key(&2));
+//     assert_eq!(any_set_parallelism_left[&1], 4);
+//     assert_eq!(any_set_parallelism_left[&2], 4);
+
+//     let join_strategies_right = vec![JoinStrategy::Cross, JoinStrategy::Right];
+//     let any_set_parallelism_right =
+//         compute_any_parallelism(&sets, &join_order, &join_strategies_right, 10);
+//     assert_eq!(any_set_parallelism_right.len(), 2);
+//     assert!(any_set_parallelism_right.contains_key(&1));
+//     assert!(any_set_parallelism_right.contains_key(&2));
+//     assert_eq!(any_set_parallelism_right[&1], 3);
+//     assert_eq!(any_set_parallelism_right[&2], 3);
+
+//     let join_strategies_outer = vec![JoinStrategy::Cross, JoinStrategy::Outer];
+//     let any_set_parallelism_outer =
+//         compute_any_parallelism(&sets, &join_order, &join_strategies_outer, 10);
+//     assert_eq!(any_set_parallelism_outer.len(), 2);
+//     assert!(any_set_parallelism_outer.contains_key(&1));
+//     assert!(any_set_parallelism_outer.contains_key(&2));
+//     assert_eq!(any_set_parallelism_outer[&1], 5);
+//     assert_eq!(any_set_parallelism_outer[&2], 5);
+// }
+
+// #[test]
+// fn any_parallelism_test_5() {
+//     let sets = vec![
+//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
+//         Some((ShardingMode::Key, create_dummy_set(vec![0, 1, 1, 4]))),
+//     ];
+
+//     let join_order = vec![0, 1];
+//     let join_strategies_inner = vec![JoinStrategy::Inner];
+
+//     // if an AnyKey and a Key are joined with a strategy other than cross it is no longer a valid
+//     // any set -> the output should be empty
+//     let any_set_parallelism_inner =
+//         compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
+//     assert_eq!(any_set_parallelism_inner.len(), 0);
+// }
+
+// #[test]
+// fn any_parallelism_test_6() {
+//     let sets = vec![Some((
+//         ShardingMode::AnyKey,
+//         create_dummy_set(vec![0, 2, 0, 1, 3]),
+//     ))];
+
+//     let join_order = vec![0];
+//     let join_strategies = vec![];
+
+//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+//     assert_eq!(any_set_parallelism_2.len(), 1);
+//     assert!(any_set_parallelism_2.contains_key(&0));
+//     assert_eq!(any_set_parallelism_2[&0], 2);
+
+//     let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
+//     assert_eq!(any_set_parallelism_4.len(), 1);
+//     assert!(any_set_parallelism_4.contains_key(&0));
+//     assert_eq!(any_set_parallelism_4[&0], 4);
+// }
+
+// #[test]
+// fn any_parallelism_test_7() {
+//     let sets = vec![
+//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 4]))),
+//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 3]))),
+//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
+//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0]))),
+//     ];
+
+//     let join_order = vec![1, 2, 0, 3];
+//     let join_strategies = vec![
+//         JoinStrategy::Inner,
+//         JoinStrategy::Right,
+//         JoinStrategy::Cross,
+//     ];
+
+//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+//     assert_eq!(any_set_parallelism_2.len(), 1);
+//     assert!(any_set_parallelism_2.contains_key(&3));
+//     assert_eq!(any_set_parallelism_2[&3], 2);
+
+//     let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
+//     assert_eq!(any_set_parallelism_3.len(), 3);
+//     assert!(any_set_parallelism_3.contains_key(&0));
+//     assert!(any_set_parallelism_3.contains_key(&1));
+//     assert!(any_set_parallelism_3.contains_key(&2));
+//     assert_eq!(any_set_parallelism_3[&0], 3);
+//     assert_eq!(any_set_parallelism_3[&1], 3);
+//     assert_eq!(any_set_parallelism_3[&2], 3);
+// }

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -13,6 +13,8 @@ use std::{
 #[cfg(test)]
 use crate::memory_domain::read_only::ReadOnlyContext;
 
+mod join_iterator;
+
 /// A composition has a composition wide id space that maps ids of
 /// the input and output sets to sets of individual functions to a unified
 /// namespace. The ids in this namespace are used to find out which

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -159,54 +159,6 @@ impl CompositionSet {
                     set_index: self.set_index,
                 })
                 .collect(),
-            // ShardingMode::AnyEach => {
-            //     // TODO: currently assume roughly equally sized elements -> could also sort
-            //     //       elements by size in descending order then use a heap queue to assign the
-            //     //       next smallest element to the smallest current set group
-            //     let mut out_sets = Vec::with_capacity(num_sets);
-            //     let base_size = self.item_list.len() / num_sets;
-            //     let remainder = self.item_list.len() % num_sets;
-            //     let mut start_idx = 0;
-            //     for i in 0..num_sets {
-            //         let extra = if i < remainder { 1 } else { 0 };
-            //         let end_idx = start_idx + base_size + extra;
-            //         out_sets.push(CompositionSet {
-            //             item_list: self.item_list[start_idx..end_idx].to_vec(),
-            //             set_index: self.set_index,
-            //         });
-            //         start_idx = end_idx;
-            //     }
-            //     out_sets
-            // }
-            // ShardingMode::AnyKey => {
-            //     // TODO: we probably want to distribute the key groups equally based on the total size
-            //     let mut key_groups: Vec<CompositionSet> = self
-            //         .item_list
-            //         .chunk_by(|(key_a, _, _), (key_b, _, _)| key_a == key_b)
-            //         .map(|new_item_list| CompositionSet {
-            //             item_list: new_item_list.to_vec(),
-            //             set_index: self.set_index,
-            //         })
-            //         .collect();
-            //     let mut out_sets = Vec::with_capacity(num_sets);
-            //     let base_size = key_groups.len() / num_sets;
-            //     let remainder = key_groups.len() % num_sets;
-            //     let mut start_idx = 0;
-            //     for i in 0..num_sets {
-            //         let extra = if i < remainder { 1 } else { 0 };
-            //         let end_idx = start_idx + base_size + extra;
-            //         let mut group_items = Vec::new();
-            //         for curr_idx in start_idx..end_idx {
-            //             group_items.append(key_groups[curr_idx].item_list.as_mut());
-            //         }
-            //         out_sets.push(CompositionSet {
-            //             item_list: group_items,
-            //             set_index: self.set_index,
-            //         });
-            //         start_idx = end_idx;
-            //     }
-            //     out_sets
-            // }
         };
     }
 
@@ -297,6 +249,11 @@ fn compute_any_parallelism(
     join_strategies: &Vec<JoinStrategy>,
     target_parallelism: usize,
 ) -> HashMap<usize, usize> {
+    let mut any_set_parallelism: HashMap<usize, usize> = HashMap::new();
+    if target_parallelism == 0 {
+        return any_set_parallelism;
+    }
+
     debug_assert!(sets.len() > 0);
     let mut curr_join_keys: HashSet<u32> = HashSet::new();
     let mut curr_any_group: Option<Vec<usize>> = None;
@@ -432,7 +389,6 @@ fn compute_any_parallelism(
     }
 
     // determine the parallelism of
-    let mut any_set_parallelism: HashMap<usize, usize> = HashMap::new();
     if fixed_parallelism < target_parallelism && !any_groups.is_empty() {
         let mut leftover_parallelism = target_parallelism / fixed_parallelism;
         loop {
@@ -492,9 +448,6 @@ pub fn get_sharding(
     let any_set_parallelism =
         compute_any_parallelism(&sets, &join_order, &join_strategies, target_parallelism);
 
-    // TODO: how do we best use this in the join iterators? -> using the old sharding approach
-    //       probably doesn't work anymore
-
     // make sure every set is in the order and has a strategy
     let mut missing_sets: Vec<_> = (0..set_num).map(|index| Some(index)).collect();
     for index in join_order.iter() {
@@ -507,26 +460,95 @@ pub fn get_sharding(
     }
     join_strategies.resize(set_num - 1, JoinStrategy::Cross);
 
-    let mut join_iter_opt = JoinIterator::new(
-        JoinStrategy::Outer,
-        None,
-        sets[join_order[0]].take(),
-        join_order[0],
-    );
-    for (set_index, startegy) in join_order[1..].iter().zip_eq(join_strategies) {
-        join_iter_opt =
-            JoinIterator::new(startegy, join_iter_opt, sets[*set_index].take(), *set_index);
+    // create the iterators later used to generate the final sharding
+    let mut join_iter = None;
+    // for (i, set_idx) in join_order.iter().enumerate() {
+    let mut i = 0;
+    while i < join_order.len() {
+        let set_idx = join_order[i];
+        if let Some((sharding, set)) = sets[set_idx].take() {
+            match sharding {
+                ShardingMode::All => {
+                    join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
+                }
+                ShardingMode::Each => {
+                    join_iter = join_iterator::SetEachIterator::new(join_iter, set, set_idx);
+                }
+                ShardingMode::Key => {
+                    let strategy = if i > 0 {
+                        join_strategies[i - 1]
+                    } else {
+                        JoinStrategy::Cross
+                    };
+                    join_iter =
+                        join_iterator::SetKeyIterator::new(join_iter, set, strategy, set_idx);
+                }
+                ShardingMode::AnyEach => {
+                    if let Some(num_groups) = any_set_parallelism.get(&set_idx) {
+                        join_iter = join_iterator::AnyIterator::new(
+                            join_iter,
+                            vec![set],
+                            vec![],
+                            vec![set_idx],
+                            *num_groups,
+                            sharding,
+                        );
+                    } else {
+                        // if we got no specific parallelism for this set we assume parallelism is 1
+                        join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
+                    }
+                }
+                ShardingMode::AnyKey => {
+                    if let Some(num_groups) = any_set_parallelism.get(&set_idx) {
+                        // get all sets that are joined together (i.e. find the next cross join)
+                        let mut joined_sets = vec![set];
+                        let mut joined_set_idcs = vec![set_idx];
+                        let mut joined_strategies = vec![];
+                        while i + 1 < join_order.len() {
+                            let next_strategy = join_strategies[i + 1];
+                            if next_strategy != JoinStrategy::Cross {
+                                let next_set_idx = join_order[i + 1];
+                                if let Some((_, set)) = sets[next_set_idx].take() {
+                                    joined_sets.push(set);
+                                    joined_set_idcs.push(next_set_idx);
+                                    joined_strategies.push(next_strategy);
+                                }
+                                // NOTE: if the set is none we just skip it -> this allows for empty
+                                //       optional sets
+                                i += 1;
+                            } else {
+                                // a cross join breaks the chain
+                                break;
+                            }
+                        }
+                        join_iter = join_iterator::AnyIterator::new(
+                            join_iter,
+                            joined_sets,
+                            joined_strategies,
+                            joined_set_idcs,
+                            *num_groups,
+                            sharding,
+                        );
+                    } else {
+                        // if we got no specific parallelism for this set we assume parallelism is 1
+                        join_iter = join_iterator::SetAllIterator::new(join_iter, set, set_idx);
+                    }
+                }
+            }
+            i += 1;
+        }
     }
 
-    if let Some(mut join_iter) = join_iter_opt {
+    // generate the sharding sets
+    if let Some(mut iter) = join_iter {
         let mut new_sets = Vec::with_capacity(set_num);
         new_sets.resize(set_num, None);
-        join_iter.fill_in(&mut new_sets);
+        iter.fill_in(&mut new_sets);
         final_sharding.push(new_sets);
-        while join_iter.advance() {
+        while iter.advance() {
             let mut advance_sets = Vec::with_capacity(set_num);
             advance_sets.resize(set_num, None);
-            join_iter.fill_in(&mut advance_sets);
+            iter.fill_in(&mut advance_sets);
             final_sharding.push(advance_sets);
         }
     }
@@ -534,310 +556,311 @@ pub fn get_sharding(
     final_sharding
 }
 
-/// Structure to hold join iterator
-#[derive(Debug)]
-struct JoinIterator {
-    left: Option<Box<JoinIterator>>,
-    right: Vec<CompositionSet>,
-    /// Index of the current interator into it's compositon set vector
-    /// The current index points to the element set by the last successful advance call
-    right_index: usize,
-    write_index: usize,
-    mode: JoinStrategy,
-    key: u32,
-}
+// /// Structure to hold join iterator
+// #[derive(Debug)]
+// struct JoinIterator {
+//     left: Option<Box<JoinIterator>>,
+//     right: Vec<CompositionSet>,
+//     /// Index of the current interator into it's compositon set vector
+//     /// The current index points to the element set by the last successful advance call
+//     right_index: usize,
+//     write_index: usize,
+//     mode: JoinStrategy,
+//     key: u32,
+// }
 
-impl JoinIterator {
-    fn new(
-        mode: JoinStrategy,
-        mut left_opt: Option<Box<Self>>,
-        right_opt: Option<(ShardingMode, CompositionSet)>,
-        write_index: usize,
-    ) -> Option<Box<Self>> {
-        if right_opt.is_none() || right_opt.as_ref().unwrap().1.is_empty() {
-            return left_opt;
-        }
-        let (set_mode, set) = right_opt.unwrap();
-        let right = set.shard(set_mode);
+// impl JoinIterator {
+//     fn new(
+//         mode: JoinStrategy,
+//         mut left_opt: Option<Box<Self>>,
+//         right_opt: Option<(ShardingMode, CompositionSet)>,
+//         write_index: usize,
+//     ) -> Option<Box<Self>> {
+//         if right_opt.is_none() || right_opt.as_ref().unwrap().1.is_empty() {
+//             return left_opt;
+//         }
+//         let (set_mode, set) = right_opt.unwrap();
+//         let right = set.shard(set_mode);
 
-        // we assume the keys of the sets are in descending order
-        debug_assert!(right.is_sorted_by_key(|set| set.item_list[0].0));
+//         // we assume the keys of the sets are in descending order
+//         debug_assert!(right.is_sorted_by_key(|set| set.item_list[0].0));
 
-        if right.is_empty() {
-            return left_opt;
-        }
+//         if right.is_empty() {
+//             return left_opt;
+//         }
 
-        let mut right_index = 0;
-        let mut key = right[0].item_list[0].0;
+//         let mut right_index = 0;
+//         let mut key = right[0].item_list[0].0;
 
-        if let Some(left) = &mut left_opt {
-            match mode {
-                JoinStrategy::Inner => {
-                    while right_index < right.len() && key != left.key {
-                        if key < left.key {
-                            right_index += 1;
-                            if right_index < right.len() {
-                                key = right[right_index].item_list[0].0;
-                            }
-                        } else {
-                            if !left.advance() {
-                                right_index = right.len();
-                            }
-                        }
-                    }
-                    if right_index == right.len() {
-                        return None;
-                    }
-                }
-                JoinStrategy::Left => {
-                    while right_index < right.len() && right[right_index].item_list[0].0 < left.key
-                    {
-                        right_index += 1;
-                    }
-                    key = left.key;
-                    if right_index == right.len() {
-                        return left_opt;
-                    }
-                }
-                JoinStrategy::Outer => {
-                    if left.key < key {
-                        key = left.key;
-                    }
-                    // else already has the correct key set
-                }
-                JoinStrategy::Right | JoinStrategy::Cross => (),
-            }
-        // there is not left iterator
-        } else {
-            match mode {
-                JoinStrategy::Inner | JoinStrategy::Left => {
-                    return None;
-                }
-                _ => (),
-            }
-        }
-        Some(Box::new(Self {
-            left: left_opt,
-            right,
-            right_index: 0,
-            write_index,
-            mode,
-            key,
-        }))
-    }
+//         if let Some(left) = &mut left_opt {
+//             match mode {
+//                 JoinStrategy::Inner => {
+//                     while right_index < right.len() && key != left.key {
+//                         if key < left.key {
+//                             right_index += 1;
+//                             if right_index < right.len() {
+//                                 key = right[right_index].item_list[0].0;
+//                             }
+//                         } else {
+//                             if !left.advance() {
+//                                 right_index = right.len();
+//                             }
+//                         }
+//                     }
+//                     if right_index == right.len() {
+//                         return None;
+//                     }
+//                 }
+//                 JoinStrategy::Left => {
+//                     while right_index < right.len() && right[right_index].item_list[0].0 < left.key
+//                     {
+//                         right_index += 1;
+//                     }
+//                     key = left.key;
+//                     if right_index == right.len() {
+//                         return left_opt;
+//                     }
+//                 }
+//                 JoinStrategy::Outer => {
+//                     if left.key < key {
+//                         key = left.key;
+//                     }
+//                     // else already has the correct key set
+//                 }
+//                 JoinStrategy::Right | JoinStrategy::Cross => (),
+//             }
+//         // there is not left iterator
+//         } else {
+//             match mode {
+//                 JoinStrategy::Inner | JoinStrategy::Left => {
+//                     return None;
+//                 }
+//                 _ => (),
+//             }
+//         }
+//         Some(Box::new(Self {
+//             left: left_opt,
+//             right,
+//             right_index: 0,
+//             write_index,
+//             mode,
+//             key,
+//         }))
+//     }
 
-    fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-        let right_filled = self.right_index < self.right.len()
-            && self.key == self.right[self.right_index].item_list[0].0;
-        if right_filled {
-            to_fill[self.write_index] = Some(self.right[self.right_index].clone());
-        }
-        if let Some(left) = &mut self.left {
-            match self.mode {
-                // modes for which always want left to fill in
-                JoinStrategy::Cross | JoinStrategy::Left => left.fill_in(to_fill),
-                // Only want to fill left if it is the one with the current key
-                JoinStrategy::Outer => {
-                    if self.key == left.key {
-                        left.fill_in(to_fill)
-                    }
-                }
-                // Only want left to fill if right has filled something in
-                JoinStrategy::Inner => {
-                    if right_filled {
-                        left.fill_in(to_fill)
-                    }
-                }
-                // Only want left to fill if right has filled and the keys match
-                JoinStrategy::Right => {
-                    if right_filled && self.key == left.key {
-                        left.fill_in(to_fill)
-                    }
-                }
-            }
-        };
-    }
+//     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
+//         let right_filled = self.right_index < self.right.len()
+//             && self.key == self.right[self.right_index].item_list[0].0;
+//         if right_filled {
+//             to_fill[self.write_index] = Some(self.right[self.right_index].clone());
+//         }
+//         if let Some(left) = &mut self.left {
+//             match self.mode {
+//                 // modes for which always want left to fill in
+//                 JoinStrategy::Cross | JoinStrategy::Left => left.fill_in(to_fill),
+//                 // Only want to fill left if it is the one with the current key
+//                 JoinStrategy::Outer => {
+//                     if self.key == left.key {
+//                         left.fill_in(to_fill)
+//                     }
+//                 }
+//                 // Only want left to fill if right has filled something in
+//                 JoinStrategy::Inner => {
+//                     if right_filled {
+//                         left.fill_in(to_fill)
+//                     }
+//                 }
+//                 // Only want left to fill if right has filled and the keys match
+//                 JoinStrategy::Right => {
+//                     if right_filled && self.key == left.key {
+//                         left.fill_in(to_fill)
+//                     }
+//                 }
+//             }
+//         };
+//     }
 
-    /// Advance the iterator by one.
-    /// Another advance call after a advance that returned false always returns false
-    /// A fill_in call after a advance that called false is undefined behaviour.
-    fn advance(&mut self) -> bool {
-        // set this when there is no more adavnce calls to be had to shortcut evaluation
-        if self.right_index == self.right.len() {
-            return false;
-        }
-        let right = &mut self.right;
-        if let Some(left) = &mut self.left {
-            match self.mode {
-                JoinStrategy::Inner => {
-                    // advance both at least once for inner
-                    // left is advanced on checking (after checking right can stil be advanced)
-                    // right is advanced after
-                    if self.right_index + 1 >= right.len() || !left.advance() {
-                        self.right_index = right.len();
-                        return false;
-                    }
-                    self.right_index += 1;
-                    self.key = right[self.right_index].item_list[0].0;
-                    while self.key != left.key {
-                        if self.key > left.key {
-                            if !left.advance() {
-                                self.right_index = right.len();
-                                return false;
-                            }
-                        // need to advance right and are able to do so
-                        } else if self.key < left.key {
-                            if self.right_index + 1 >= right.len() {
-                                self.right_index = right.len();
-                                return false;
-                            } else {
-                                self.right_index += 1;
-                                self.key = right[self.right_index].item_list[0].0;
-                            }
-                        }
-                    }
-                    true
-                }
-                JoinStrategy::Left => {
-                    // advance left and see if we can match
-                    if left.advance() {
-                        while self.right_index + 1 < right.len()
-                            && right[self.right_index].item_list[0].0 < left.key
-                        {
-                            self.right_index += 1;
-                        }
-                        // after this the key is guaranteed to be equal to the left key or bigger
-                        // so if the keys match that will be fine for copy in, otherwise this will be skipped
-                        // if the key already equal or bigger, it was not advanced
-                        self.key = left.key;
-                        true
-                    } else {
-                        self.right_index = right.len();
-                        false
-                    }
-                }
-                JoinStrategy::Right => {
-                    if self.right_index + 1 >= right.len() {
-                        self.right_index = right.len();
-                        return false;
-                    }
-                    self.right_index += 1;
-                    self.key = right[self.right_index].item_list[0].0;
-                    while self.key > left.key {
-                        if !left.advance() {
-                            break;
-                        }
-                    }
-                    true
-                }
-                JoinStrategy::Outer => {
-                    let current_self_key = right[self.right_index].item_list[0].0;
-                    let right_can_be_advanced = self.right_index + 1 < right.len();
-                    // check if one of the already known keys is bigger, if so we know we can adavance
-                    if self.key < left.key {
-                        // last key was set from right, since left is bigger
-                        debug_assert_eq!(self.key, current_self_key);
-                        // if right can be advance it should be advanced, otherwise just set key to left one
-                        if right_can_be_advanced {
-                            self.right_index += 1;
-                            // new right might still be smaller than left key
-                            self.key = u32::min(right[self.right_index].item_list[0].0, left.key);
-                        } else {
-                            self.key = left.key;
-                        }
-                        true
-                    } else if self.key < current_self_key {
-                        // the last key was set from left, since right is bigger
-                        debug_assert_eq!(self.key, left.key);
-                        // if left can be adnvanced it should be, if not move
-                        if left.advance() {
-                            // new left key might still be smaller than right
-                            self.key = u32::min(right[self.right_index].item_list[0].0, left.key);
-                        } else {
-                            //  left did not advance, so set key to current right key
-                            self.key = current_self_key;
-                        }
-                        true
-                    } else if self.key == left.key && self.key == current_self_key {
-                        // both keys are the same, so advance any that are possible to advance and take new key from there
-                        let left_advance_success = left.advance();
-                        if right_can_be_advanced {
-                            self.right_index += 1;
-                        }
-                        match (right_can_be_advanced, left_advance_success) {
-                            (true, true) => {
-                                self.key =
-                                    u32::min(right[self.right_index].item_list[0].0, left.key);
-                                true
-                            }
-                            (true, false) => {
-                                self.key = right[self.right_index].item_list[0].0;
-                                true
-                            }
-                            (false, true) => {
-                                self.key = left.key;
-                                true
-                            }
-                            (false, false) => {
-                                self.right_index = right.len();
-                                false
-                            }
-                        }
-                    } else {
-                        // the key is already set to the bigger of the two current keys, try to advance that one
-                        if current_self_key == left.key {
-                            let did_advance = left.advance();
-                            self.key = left.key;
-                            did_advance
-                        } else {
-                            if right_can_be_advanced {
-                                self.right_index += 1;
-                                self.key = right[self.right_index].item_list[0].0;
-                            }
-                            right_can_be_advanced
-                        }
-                    }
-                }
-                JoinStrategy::Cross => {
-                    if self.right_index + 1 < right.len() {
-                        self.right_index += 1;
-                        self.key = right[self.right_index].item_list[0].0;
-                        true
-                    } else if left.advance() {
-                        self.right_index = 0;
-                        self.key = right[0].item_list[0].0;
-                        true
-                    } else {
-                        // set right index to len so we can't accidentally copy something
-                        self.right_index = right.len();
-                        false
-                    }
-                }
-            }
-        } else {
-            if self.right_index + 1 >= right.len() {
-                self.right_index = right.len();
-                false
-            } else {
-                // advancing only makes sense for certain modes here
-                if self.mode == JoinStrategy::Right
-                    || self.mode == JoinStrategy::Outer
-                    || self.mode == JoinStrategy::Cross
-                {
-                    self.right_index += 1;
-                    self.key = right[self.right_index].item_list[0].0;
-                    true
-                } else {
-                    panic!("Should never have join iterator with left or inner that has None for the left value");
-                }
-            }
-        }
-    }
-}
+//     /// Advance the iterator by one.
+//     /// Another advance call after a advance that returned false always returns false
+//     /// A fill_in call after a advance that called false is undefined behaviour.
+//     fn advance(&mut self) -> bool {
+//         // set this when there is no more adavnce calls to be had to shortcut evaluation
+//         if self.right_index == self.right.len() {
+//             return false;
+//         }
+//         let right = &mut self.right;
+//         if let Some(left) = &mut self.left {
+//             match self.mode {
+//                 JoinStrategy::Inner => {
+//                     // advance both at least once for inner
+//                     // left is advanced on checking (after checking right can stil be advanced)
+//                     // right is advanced after
+//                     if self.right_index + 1 >= right.len() || !left.advance() {
+//                         self.right_index = right.len();
+//                         return false;
+//                     }
+//                     self.right_index += 1;
+//                     self.key = right[self.right_index].item_list[0].0;
+//                     while self.key != left.key {
+//                         if self.key > left.key {
+//                             if !left.advance() {
+//                                 self.right_index = right.len();
+//                                 return false;
+//                             }
+//                         // need to advance right and are able to do so
+//                         } else if self.key < left.key {
+//                             if self.right_index + 1 >= right.len() {
+//                                 self.right_index = right.len();
+//                                 return false;
+//                             } else {
+//                                 self.right_index += 1;
+//                                 self.key = right[self.right_index].item_list[0].0;
+//                             }
+//                         }
+//                     }
+//                     true
+//                 }
+//                 JoinStrategy::Left => {
+//                     // advance left and see if we can match
+//                     if left.advance() {
+//                         while self.right_index + 1 < right.len()
+//                             && right[self.right_index].item_list[0].0 < left.key
+//                         {
+//                             self.right_index += 1;
+//                         }
+//                         // after this the key is guaranteed to be equal to the left key or bigger
+//                         // so if the keys match that will be fine for copy in, otherwise this will be skipped
+//                         // if the key already equal or bigger, it was not advanced
+//                         self.key = left.key;
+//                         true
+//                     } else {
+//                         self.right_index = right.len();
+//                         false
+//                     }
+//                 }
+//                 JoinStrategy::Right => {
+//                     if self.right_index + 1 >= right.len() {
+//                         self.right_index = right.len();
+//                         return false;
+//                     }
+//                     self.right_index += 1;
+//                     self.key = right[self.right_index].item_list[0].0;
+//                     while self.key > left.key {
+//                         if !left.advance() {
+//                             break;
+//                         }
+//                     }
+//                     true
+//                 }
+//                 JoinStrategy::Outer => {
+//                     let current_self_key = right[self.right_index].item_list[0].0;
+//                     let right_can_be_advanced = self.right_index + 1 < right.len();
+//                     // check if one of the already known keys is bigger, if so we know we can adavance
+//                     if self.key < left.key {
+//                         // last key was set from right, since left is bigger
+//                         debug_assert_eq!(self.key, current_self_key);
+//                         // if right can be advance it should be advanced, otherwise just set key to left one
+//                         if right_can_be_advanced {
+//                             self.right_index += 1;
+//                             // new right might still be smaller than left key
+//                             self.key = u32::min(right[self.right_index].item_list[0].0, left.key);
+//                         } else {
+//                             self.key = left.key;
+//                         }
+//                         true
+//                     } else if self.key < current_self_key {
+//                         // the last key was set from left, since right is bigger
+//                         debug_assert_eq!(self.key, left.key);
+//                         // if left can be adnvanced it should be, if not move
+//                         if left.advance() {
+//                             // new left key might still be smaller than right
+//                             self.key = u32::min(right[self.right_index].item_list[0].0, left.key);
+//                         } else {
+//                             //  left did not advance, so set key to current right key
+//                             self.key = current_self_key;
+//                         }
+//                         true
+//                     } else if self.key == left.key && self.key == current_self_key {
+//                         // both keys are the same, so advance any that are possible to advance and take new key from there
+//                         let left_advance_success = left.advance();
+//                         if right_can_be_advanced {
+//                             self.right_index += 1;
+//                         }
+//                         match (right_can_be_advanced, left_advance_success) {
+//                             (true, true) => {
+//                                 self.key =
+//                                     u32::min(right[self.right_index].item_list[0].0, left.key);
+//                                 true
+//                             }
+//                             (true, false) => {
+//                                 self.key = right[self.right_index].item_list[0].0;
+//                                 true
+//                             }
+//                             (false, true) => {
+//                                 self.key = left.key;
+//                                 true
+//                             }
+//                             (false, false) => {
+//                                 self.right_index = right.len();
+//                                 false
+//                             }
+//                         }
+//                     } else {
+//                         // the key is already set to the bigger of the two current keys, try to advance that one
+//                         if current_self_key == left.key {
+//                             let did_advance = left.advance();
+//                             self.key = left.key;
+//                             did_advance
+//                         } else {
+//                             if right_can_be_advanced {
+//                                 self.right_index += 1;
+//                                 self.key = right[self.right_index].item_list[0].0;
+//                             }
+//                             right_can_be_advanced
+//                         }
+//                     }
+//                 }
+//                 JoinStrategy::Cross => {
+//                     if self.right_index + 1 < right.len() {
+//                         self.right_index += 1;
+//                         self.key = right[self.right_index].item_list[0].0;
+//                         true
+//                     } else if left.advance() {
+//                         self.right_index = 0;
+//                         self.key = right[0].item_list[0].0;
+//                         true
+//                     } else {
+//                         // set right index to len so we can't accidentally copy something
+//                         self.right_index = right.len();
+//                         false
+//                     }
+//                 }
+//             }
+//         } else {
+//             if self.right_index + 1 >= right.len() {
+//                 self.right_index = right.len();
+//                 false
+//             } else {
+//                 // advancing only makes sense for certain modes here
+//                 if self.mode == JoinStrategy::Right
+//                     || self.mode == JoinStrategy::Outer
+//                     || self.mode == JoinStrategy::Cross
+//                 {
+//                     self.right_index += 1;
+//                     self.key = right[self.right_index].item_list[0].0;
+//                     true
+//                 } else {
+//                     panic!("Should never have join iterator with left or inner that has None for the left value");
+//                 }
+//             }
+//         }
+//     }
+// }
 
-// tests
+//=======
+// TESTS
 
-/// Create a dummy set from a vector of keys
+/// Creates a dummy set from a vector of keys.
 /// The item indexes in the composition set are qual to the index of the key in the input.
 /// Keys do not need to be in correct order, but they will be sorted after producing.
 /// This is to allow to have keys with lower item indexes but higher keys and vice versa.
@@ -856,16 +879,16 @@ fn create_dummy_set(keys: Vec<u32>) -> CompositionSet {
     }
 }
 
-/// An array of options for expected sets in the input set vec produced by a sharing
+/// An array of options for expected sets in the input set vec produced by a sharing.
 #[cfg(test)]
 type SetGroup = Vec<Option<ExpectedSet>>;
 
-/// An array of tuples with the expected keys and item indexes for the items in a set
+/// An array of tuples with the expected keys and item indexes for the items in a set.
 #[cfg(test)]
 type ExpectedSet = Vec<(u32, usize)>;
 
 #[cfg(test)]
-/// The expected is a list of all vectors of generated sets
+/// The expected is a list of all vectors of generated sets.
 fn check_sharding(actual: Vec<Vec<Option<CompositionSet>>>, expected: Vec<SetGroup>) {
     assert_eq!(
         expected.len(),

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -3,7 +3,11 @@ use dandelion_commons::{
     err_dandelion, DandelionError, DandelionResult, DispatcherError, FunctionId,
 };
 use itertools::Itertools;
-use std::{collections::BTreeMap, sync::Arc, vec};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+    vec,
+};
 
 #[cfg(test)]
 use crate::memory_domain::read_only::ReadOnlyContext;
@@ -24,6 +28,8 @@ pub enum ShardingMode {
     All,
     Each,
     Key,
+    AnyEach,
+    AnyKey,
 }
 
 // TODO remove  one of left/right to simplify handling, push switching order into the parsing layer
@@ -100,6 +106,17 @@ impl CompositionSet {
         self.item_list.len()
     }
 
+    pub fn sharded_len(&self, mode: ShardingMode) -> usize {
+        match mode {
+            ShardingMode::Each => self.len(),
+            ShardingMode::Key => self
+                .item_list
+                .chunk_by(|(key_a, _, _), (key_b, _, _)| key_a == key_b)
+                .count(),
+            ShardingMode::All | _ => 1, // any are resource dependent so return 1
+        }
+    }
+
     pub fn get_set_idx(&self) -> usize {
         self.set_index
     }
@@ -123,20 +140,15 @@ impl CompositionSet {
             ShardingMode::All => {
                 vec![self]
             }
-            ShardingMode::Key => {
-                let CompositionSet {
-                    item_list,
-                    set_index,
-                } = self;
-                item_list
-                    .chunk_by(|(key_a, _, _), (key_b, _, _)| key_a == key_b)
-                    .map(|new_item_list| CompositionSet {
-                        item_list: new_item_list.to_vec(),
-                        set_index: set_index,
-                    })
-                    .collect()
-            }
-            ShardingMode::Each => self
+            ShardingMode::Key | ShardingMode::AnyKey => self
+                .item_list
+                .chunk_by(|(key_a, _, _), (key_b, _, _)| key_a == key_b)
+                .map(|new_item_list| CompositionSet {
+                    item_list: new_item_list.to_vec(),
+                    set_index: self.set_index,
+                })
+                .collect(),
+            ShardingMode::Each | ShardingMode::AnyEach => self
                 .item_list
                 .into_iter()
                 .map(|item| CompositionSet {
@@ -144,6 +156,54 @@ impl CompositionSet {
                     set_index: self.set_index,
                 })
                 .collect(),
+            // ShardingMode::AnyEach => {
+            //     // TODO: currently assume roughly equally sized elements -> could also sort
+            //     //       elements by size in descending order then use a heap queue to assign the
+            //     //       next smallest element to the smallest current set group
+            //     let mut out_sets = Vec::with_capacity(num_sets);
+            //     let base_size = self.item_list.len() / num_sets;
+            //     let remainder = self.item_list.len() % num_sets;
+            //     let mut start_idx = 0;
+            //     for i in 0..num_sets {
+            //         let extra = if i < remainder { 1 } else { 0 };
+            //         let end_idx = start_idx + base_size + extra;
+            //         out_sets.push(CompositionSet {
+            //             item_list: self.item_list[start_idx..end_idx].to_vec(),
+            //             set_index: self.set_index,
+            //         });
+            //         start_idx = end_idx;
+            //     }
+            //     out_sets
+            // }
+            // ShardingMode::AnyKey => {
+            //     // TODO: we probably want to distribute the key groups equally based on the total size
+            //     let mut key_groups: Vec<CompositionSet> = self
+            //         .item_list
+            //         .chunk_by(|(key_a, _, _), (key_b, _, _)| key_a == key_b)
+            //         .map(|new_item_list| CompositionSet {
+            //             item_list: new_item_list.to_vec(),
+            //             set_index: self.set_index,
+            //         })
+            //         .collect();
+            //     let mut out_sets = Vec::with_capacity(num_sets);
+            //     let base_size = key_groups.len() / num_sets;
+            //     let remainder = key_groups.len() % num_sets;
+            //     let mut start_idx = 0;
+            //     for i in 0..num_sets {
+            //         let extra = if i < remainder { 1 } else { 0 };
+            //         let end_idx = start_idx + base_size + extra;
+            //         let mut group_items = Vec::new();
+            //         for curr_idx in start_idx..end_idx {
+            //             group_items.append(key_groups[curr_idx].item_list.as_mut());
+            //         }
+            //         out_sets.push(CompositionSet {
+            //             item_list: group_items,
+            //             set_index: self.set_index,
+            //         });
+            //         start_idx = end_idx;
+            //     }
+            //     out_sets
+            // }
         };
     }
 
@@ -160,6 +220,20 @@ impl CompositionSet {
         self.item_list.extend(item_list.into_iter());
         self.item_list.sort_unstable_by_key(|a| a.0);
         return Ok(());
+    }
+
+    pub fn combine_keys_with_set(&self, other: &mut HashSet<u32>, intersect: bool) {
+        if intersect {
+            for (key, _, _) in self.item_list.iter() {
+                if !other.contains(key) {
+                    other.remove(key);
+                }
+            }
+        } else {
+            for (key, _, _) in self.item_list.iter() {
+                other.insert(*key);
+            }
+        }
     }
 }
 
@@ -211,6 +285,179 @@ impl<'origin> IntoIterator for &'origin CompositionSet {
     }
 }
 
+// NOTE: assumes at least one element
+fn compute_any_parallelism(
+    sets: &Vec<Option<(ShardingMode, CompositionSet)>>,
+    join_order: &Vec<usize>,
+    join_strategies: &Vec<JoinStrategy>,
+    target_parallelism: usize,
+) -> HashMap<usize, usize> {
+    debug_assert!(sets.len() > 0);
+    let mut curr_join_keys: HashSet<u32> = HashSet::new();
+    let mut curr_any_group: Option<Vec<usize>> = None;
+    let mut any_groups: Vec<(Vec<usize>, usize)> = Vec::new();
+    let mut fixed_parallelism = 1;
+    for (set_index, strategy) in join_order[1..].iter().zip_eq(join_strategies) {
+        if sets[*set_index].is_none() {
+            match strategy {
+                JoinStrategy::Left | JoinStrategy::Outer => {
+                    // for left and outer joins this set may be none
+                    if let Some(idx_list) = curr_any_group.as_mut() {
+                        idx_list.push(*set_index);
+                    }
+                }
+                _ => {
+                    curr_any_group = None;
+                    curr_join_keys.clear();
+                }
+            }
+        }
+        let (sharding, set) = sets[*set_index].as_ref().unwrap();
+        match *sharding {
+            ShardingMode::AnyEach => {
+                // push current group or add parallelism of current join
+                if let Some(idx_list) = curr_any_group.take() {
+                    any_groups.push((idx_list, curr_join_keys.len()));
+                } else if !curr_join_keys.is_empty() {
+                    fixed_parallelism *= curr_join_keys.len();
+                    curr_join_keys.clear();
+                }
+
+                // push this group (each cannot be joined)
+                any_groups.push((vec![*set_index], set.len()));
+            }
+            ShardingMode::AnyKey => {
+                match strategy {
+                    JoinStrategy::Left => {
+                        // only add the set index to the list
+                        if let Some(idx_list) = curr_any_group.as_mut() {
+                            idx_list.push(*set_index);
+                        }
+                    }
+                    JoinStrategy::Right => {
+                        // only use this set's keys
+                        curr_join_keys.clear();
+                        set.combine_keys_with_set(&mut curr_join_keys, true);
+                        if let Some(idx_list) = curr_any_group.as_mut() {
+                            idx_list.push(*set_index);
+                        } else {
+                            curr_any_group = Some(vec![*set_index]);
+                        }
+                    }
+                    JoinStrategy::Inner => {
+                        // use key intersection
+                        set.combine_keys_with_set(&mut curr_join_keys, true);
+                        if let Some(idx_list) = curr_any_group.as_mut() {
+                            idx_list.push(*set_index);
+                        }
+                    }
+                    JoinStrategy::Outer => {
+                        // use key union
+                        set.combine_keys_with_set(&mut curr_join_keys, false);
+                        if let Some(idx_list) = curr_any_group.as_mut() {
+                            idx_list.push(*set_index);
+                        } else {
+                            curr_any_group = Some(vec![*set_index]);
+                        }
+                    }
+                    JoinStrategy::Cross => {
+                        // push current group or add parallelism of current join
+                        if let Some(idx_list) = curr_any_group.take() {
+                            any_groups.push((idx_list, curr_join_keys.len()));
+                        } else if !curr_join_keys.is_empty() {
+                            fixed_parallelism *= curr_join_keys.len();
+                            curr_join_keys.clear();
+                        }
+                        // create next group
+                        curr_join_keys.clear();
+                        set.combine_keys_with_set(&mut curr_join_keys, true);
+                        curr_any_group = Some(vec![*set_index]);
+                    }
+                }
+            }
+            ShardingMode::Key => {
+                // if an AnyKey is joined with a normal Key it becomes invalid except for cross joins
+                if *strategy == JoinStrategy::Cross {
+                    if let Some(idx_list) = curr_any_group.take() {
+                        any_groups.push((idx_list, curr_join_keys.len()));
+                    }
+                    curr_join_keys.clear();
+                } else {
+                    curr_any_group = None;
+                    if *strategy == JoinStrategy::Right {
+                        curr_join_keys.clear(); // -> for right we only care about this set's keys
+                    }
+                    if *strategy != JoinStrategy::Left {
+                        set.combine_keys_with_set(
+                            &mut curr_join_keys,
+                            *strategy != JoinStrategy::Outer,
+                        );
+                    }
+                }
+            }
+            _ => {
+                // push current group or add parallelism of current join
+                if let Some(idx_list) = curr_any_group.take() {
+                    any_groups.push((idx_list, curr_join_keys.len()));
+                } else if !curr_join_keys.is_empty() {
+                    fixed_parallelism *= curr_join_keys.len();
+                    curr_join_keys.clear();
+                }
+                // add parallelism of this set
+                fixed_parallelism *= set.sharded_len(*sharding);
+            }
+        }
+    }
+
+    // push current group or add parallelism of current join
+    if let Some(idx_list) = curr_any_group.take() {
+        any_groups.push((idx_list, curr_join_keys.len()));
+    } else if !curr_join_keys.is_empty() {
+        fixed_parallelism *= curr_join_keys.len();
+        curr_join_keys.clear();
+    }
+
+    // determine the parallelism of
+    let mut any_set_parallelism: HashMap<usize, usize> = HashMap::new();
+    if fixed_parallelism < target_parallelism {
+        let mut leftover_parallelism = target_parallelism / fixed_parallelism;
+        loop {
+            let mut best_idx = 0;
+            let mut best_dist = 0.0;
+            for (i, (_, max_p)) in any_groups.iter().enumerate() {
+                let remainder = leftover_parallelism % max_p;
+                if remainder == 0 {
+                    best_idx = i;
+                    break;
+                }
+                let dist = (remainder) as f64 / (*max_p) as f64;
+                if best_dist == 0.0 || dist < best_dist {
+                    best_idx = i;
+                    best_dist = dist;
+                }
+            }
+
+            // if the best set has fewer elements than the leftover parallelization we continue and
+            // check if we can find another set to parallelize over in addition to the found one
+            if best_dist >= 1.0 {
+                for set_idx in any_groups[best_idx].0.iter() {
+                    any_set_parallelism.insert(*set_idx, any_groups[best_idx].1);
+                }
+                leftover_parallelism /= any_groups[best_idx].1;
+                if leftover_parallelism <= 1 {
+                    break;
+                }
+            } else {
+                for set_idx in any_groups[best_idx].0.iter() {
+                    any_set_parallelism.insert(*set_idx, leftover_parallelism);
+                }
+                break;
+            }
+        }
+    }
+    any_set_parallelism
+}
+
 pub fn get_sharding(
     mut sets: Vec<Option<(ShardingMode, CompositionSet)>>,
     mut join_order: Vec<usize>,
@@ -222,6 +469,13 @@ pub fn get_sharding(
     if set_num == 0 {
         return final_sharding;
     }
+
+    let target_parallelism = 10; // TODO: move to arg
+    let any_set_parallelism =
+        compute_any_parallelism(&sets, &join_order, &join_strategies, target_parallelism);
+
+    // TODO: how do we best use this in the join iterators? -> using the old sharding approach
+    //       probably doesn't work anymore
 
     // make sure every set is in the order and has a strategy
     let mut missing_sets: Vec<_> = (0..set_num).map(|index| Some(index)).collect();

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -4,6 +4,7 @@ use dandelion_commons::{
 };
 use itertools::Itertools;
 use std::{
+    cmp,
     collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
     vec,
@@ -224,11 +225,13 @@ impl CompositionSet {
 
     pub fn combine_keys_with_set(&self, other: &mut HashSet<u32>, intersect: bool) {
         if intersect {
+            let mut new_set = HashSet::new();
             for (key, _, _) in self.item_list.iter() {
-                if !other.contains(key) {
-                    other.remove(key);
+                if other.contains(key) {
+                    new_set.insert(*key);
                 }
             }
+            *other = new_set;
         } else {
             for (key, _, _) in self.item_list.iter() {
                 other.insert(*key);
@@ -297,7 +300,12 @@ fn compute_any_parallelism(
     let mut curr_any_group: Option<Vec<usize>> = None;
     let mut any_groups: Vec<(Vec<usize>, usize)> = Vec::new();
     let mut fixed_parallelism = 1;
-    for (set_index, strategy) in join_order[1..].iter().zip_eq(join_strategies) {
+    for (i, set_index) in join_order.iter().enumerate() {
+        let strategy = if i > 0 {
+            join_strategies[i - 1]
+        } else {
+            JoinStrategy::Cross
+        };
         if sets[*set_index].is_none() {
             match strategy {
                 JoinStrategy::Left | JoinStrategy::Outer => {
@@ -337,7 +345,7 @@ fn compute_any_parallelism(
                     JoinStrategy::Right => {
                         // only use this set's keys
                         curr_join_keys.clear();
-                        set.combine_keys_with_set(&mut curr_join_keys, true);
+                        set.combine_keys_with_set(&mut curr_join_keys, false);
                         if let Some(idx_list) = curr_any_group.as_mut() {
                             idx_list.push(*set_index);
                         } else {
@@ -370,27 +378,27 @@ fn compute_any_parallelism(
                         }
                         // create next group
                         curr_join_keys.clear();
-                        set.combine_keys_with_set(&mut curr_join_keys, true);
+                        set.combine_keys_with_set(&mut curr_join_keys, false);
                         curr_any_group = Some(vec![*set_index]);
                     }
                 }
             }
             ShardingMode::Key => {
                 // if an AnyKey is joined with a normal Key it becomes invalid except for cross joins
-                if *strategy == JoinStrategy::Cross {
+                if strategy == JoinStrategy::Cross {
                     if let Some(idx_list) = curr_any_group.take() {
                         any_groups.push((idx_list, curr_join_keys.len()));
                     }
                     curr_join_keys.clear();
                 } else {
                     curr_any_group = None;
-                    if *strategy == JoinStrategy::Right {
+                    if strategy == JoinStrategy::Right {
                         curr_join_keys.clear(); // -> for right we only care about this set's keys
                     }
-                    if *strategy != JoinStrategy::Left {
+                    if strategy != JoinStrategy::Left {
                         set.combine_keys_with_set(
                             &mut curr_join_keys,
-                            *strategy != JoinStrategy::Outer,
+                            strategy != JoinStrategy::Outer,
                         );
                     }
                 }
@@ -419,15 +427,16 @@ fn compute_any_parallelism(
 
     // determine the parallelism of
     let mut any_set_parallelism: HashMap<usize, usize> = HashMap::new();
-    if fixed_parallelism < target_parallelism {
+    if fixed_parallelism < target_parallelism && !any_groups.is_empty() {
         let mut leftover_parallelism = target_parallelism / fixed_parallelism;
         loop {
             let mut best_idx = 0;
             let mut best_dist = 0.0;
             for (i, (_, max_p)) in any_groups.iter().enumerate() {
-                let remainder = leftover_parallelism % max_p;
+                let remainder = max_p % leftover_parallelism;
                 if remainder == 0 {
                     best_idx = i;
+                    best_dist = 0.0;
                     break;
                 }
                 let dist = (remainder) as f64 / (*max_p) as f64;
@@ -449,7 +458,10 @@ fn compute_any_parallelism(
                 }
             } else {
                 for set_idx in any_groups[best_idx].0.iter() {
-                    any_set_parallelism.insert(*set_idx, leftover_parallelism);
+                    any_set_parallelism.insert(
+                        *set_idx,
+                        cmp::min(leftover_parallelism, any_groups[best_idx].1),
+                    );
                 }
                 break;
             }
@@ -1117,4 +1129,151 @@ fn join_it_chain_test() {
 
     print_sharding(&sharding);
     check_sharding(sharding, expected);
+}
+
+#[test]
+fn any_parallelism_test_1() {
+    let sets = vec![
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1]))),
+        Some((
+            ShardingMode::AnyEach,
+            create_dummy_set(vec![0, 1, 2, 3, 4, 5]),
+        )),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1, 2, 3]))),
+    ];
+
+    let join_order = vec![0, 1, 2];
+    let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
+
+    let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
+    assert_eq!(any_set_parallelism_6.len(), 1);
+    assert!(any_set_parallelism_6.contains_key(&1));
+    assert_eq!(any_set_parallelism_6[&1], 6);
+
+    let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
+    assert_eq!(any_set_parallelism_3.len(), 1);
+    assert!(any_set_parallelism_3.contains_key(&1));
+    assert_eq!(any_set_parallelism_3[&1], 3);
+
+    let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
+    assert_eq!(any_set_parallelism_4.len(), 1);
+    assert!(any_set_parallelism_4.contains_key(&2));
+    assert_eq!(any_set_parallelism_4[&2], 4);
+}
+
+#[test]
+fn any_parallelism_test_2() {
+    let sets = vec![
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1, 2]))),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1]))),
+    ];
+
+    let join_order = vec![0, 1];
+    let join_strategies = vec![JoinStrategy::Cross];
+
+    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+    assert_eq!(any_set_parallelism_2.len(), 1);
+    assert!(any_set_parallelism_2.contains_key(&1));
+    assert_eq!(any_set_parallelism_2[&1], 2);
+
+    let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
+    assert_eq!(any_set_parallelism_3.len(), 1);
+    assert!(any_set_parallelism_3.contains_key(&0));
+    assert_eq!(any_set_parallelism_3[&0], 3);
+
+    let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
+    assert_eq!(any_set_parallelism_6.len(), 2);
+    assert!(any_set_parallelism_6.contains_key(&0));
+    assert!(any_set_parallelism_6.contains_key(&1));
+    assert_eq!(any_set_parallelism_6[&0], 3);
+    assert_eq!(any_set_parallelism_6[&1], 2);
+}
+
+#[test]
+fn any_parallelism_test_3() {
+    let sets = vec![
+        Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0, 0]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
+    ];
+
+    let join_order = vec![0, 1, 2];
+    let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
+
+    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+    assert_eq!(any_set_parallelism_2.len(), 0);
+
+    let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
+    assert_eq!(any_set_parallelism_4.len(), 1);
+    assert!(any_set_parallelism_4.contains_key(&2));
+    assert_eq!(any_set_parallelism_4[&2], 2);
+
+    let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
+    assert_eq!(any_set_parallelism_6.len(), 1);
+    assert!(any_set_parallelism_6.contains_key(&1));
+    assert_eq!(any_set_parallelism_6[&1], 3);
+}
+
+#[test]
+fn any_parallelism_test_4() {
+    let sets = vec![
+        Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1, 4]))),
+    ];
+
+    let join_order = vec![0, 1, 2];
+
+    let join_strategies_inner = vec![JoinStrategy::Cross, JoinStrategy::Inner];
+    let any_set_parallelism_inner =
+        compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
+    assert_eq!(any_set_parallelism_inner.len(), 2);
+    assert!(any_set_parallelism_inner.contains_key(&1));
+    assert!(any_set_parallelism_inner.contains_key(&2));
+    assert_eq!(any_set_parallelism_inner[&1], 2);
+    assert_eq!(any_set_parallelism_inner[&2], 2);
+
+    let join_strategies_left = vec![JoinStrategy::Cross, JoinStrategy::Left];
+    let any_set_parallelism_left =
+        compute_any_parallelism(&sets, &join_order, &join_strategies_left, 10);
+    assert_eq!(any_set_parallelism_left.len(), 2);
+    assert!(any_set_parallelism_left.contains_key(&1));
+    assert!(any_set_parallelism_left.contains_key(&2));
+    assert_eq!(any_set_parallelism_left[&1], 4);
+    assert_eq!(any_set_parallelism_left[&2], 4);
+
+    let join_strategies_right = vec![JoinStrategy::Cross, JoinStrategy::Right];
+    let any_set_parallelism_right =
+        compute_any_parallelism(&sets, &join_order, &join_strategies_right, 10);
+    assert_eq!(any_set_parallelism_right.len(), 2);
+    assert!(any_set_parallelism_right.contains_key(&1));
+    assert!(any_set_parallelism_right.contains_key(&2));
+    assert_eq!(any_set_parallelism_right[&1], 3);
+    assert_eq!(any_set_parallelism_right[&2], 3);
+
+    let join_strategies_outer = vec![JoinStrategy::Cross, JoinStrategy::Outer];
+    let any_set_parallelism_outer =
+        compute_any_parallelism(&sets, &join_order, &join_strategies_outer, 10);
+    assert_eq!(any_set_parallelism_outer.len(), 2);
+    assert!(any_set_parallelism_outer.contains_key(&1));
+    assert!(any_set_parallelism_outer.contains_key(&2));
+    assert_eq!(any_set_parallelism_outer[&1], 5);
+    assert_eq!(any_set_parallelism_outer[&2], 5);
+}
+
+#[test]
+fn any_parallelism_test_5() {
+    let sets = vec![
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
+        Some((ShardingMode::Key, create_dummy_set(vec![0, 1, 1, 4]))),
+    ];
+
+    let join_order = vec![0, 1];
+    let join_strategies_inner = vec![JoinStrategy::Inner];
+
+    // if an AnyKey and a Key are joined with a strategy other than cross it is no longer a valid
+    // any set -> the output should be empty
+    let any_set_parallelism_inner =
+        compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
+    assert_eq!(any_set_parallelism_inner.len(), 0);
 }

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -326,6 +326,7 @@ fn compute_any_parallelism(
                 // push current group or add parallelism of current join
                 if let Some(idx_list) = curr_any_group.take() {
                     any_groups.push((idx_list, curr_join_keys.len()));
+                    curr_join_keys.clear();
                 } else if !curr_join_keys.is_empty() {
                     fixed_parallelism *= curr_join_keys.len();
                     curr_join_keys.clear();
@@ -372,6 +373,7 @@ fn compute_any_parallelism(
                         // push current group or add parallelism of current join
                         if let Some(idx_list) = curr_any_group.take() {
                             any_groups.push((idx_list, curr_join_keys.len()));
+                            curr_join_keys.clear();
                         } else if !curr_join_keys.is_empty() {
                             fixed_parallelism *= curr_join_keys.len();
                             curr_join_keys.clear();
@@ -407,6 +409,7 @@ fn compute_any_parallelism(
                 // push current group or add parallelism of current join
                 if let Some(idx_list) = curr_any_group.take() {
                     any_groups.push((idx_list, curr_join_keys.len()));
+                    curr_join_keys.clear();
                 } else if !curr_join_keys.is_empty() {
                     fixed_parallelism *= curr_join_keys.len();
                     curr_join_keys.clear();
@@ -420,6 +423,7 @@ fn compute_any_parallelism(
     // push current group or add parallelism of current join
     if let Some(idx_list) = curr_any_group.take() {
         any_groups.push((idx_list, curr_join_keys.len()));
+        curr_join_keys.clear();
     } else if !curr_join_keys.is_empty() {
         fixed_parallelism *= curr_join_keys.len();
         curr_join_keys.clear();
@@ -1276,4 +1280,56 @@ fn any_parallelism_test_5() {
     let any_set_parallelism_inner =
         compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
     assert_eq!(any_set_parallelism_inner.len(), 0);
+}
+
+#[test]
+fn any_parallelism_test_6() {
+    let sets = vec![Some((
+        ShardingMode::AnyKey,
+        create_dummy_set(vec![0, 2, 0, 1, 3]),
+    ))];
+
+    let join_order = vec![0];
+    let join_strategies = vec![];
+
+    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+    assert_eq!(any_set_parallelism_2.len(), 1);
+    assert!(any_set_parallelism_2.contains_key(&0));
+    assert_eq!(any_set_parallelism_2[&0], 2);
+
+    let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
+    assert_eq!(any_set_parallelism_4.len(), 1);
+    assert!(any_set_parallelism_4.contains_key(&0));
+    assert_eq!(any_set_parallelism_4[&0], 4);
+}
+
+#[test]
+fn any_parallelism_test_7() {
+    let sets = vec![
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 4]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 3]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0]))),
+    ];
+
+    let join_order = vec![1, 2, 0, 3];
+    let join_strategies = vec![
+        JoinStrategy::Inner,
+        JoinStrategy::Right,
+        JoinStrategy::Cross,
+    ];
+
+    let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
+    assert_eq!(any_set_parallelism_2.len(), 1);
+    assert!(any_set_parallelism_2.contains_key(&3));
+    assert_eq!(any_set_parallelism_2[&3], 2);
+
+    let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
+    assert_eq!(any_set_parallelism_3.len(), 3);
+    assert!(any_set_parallelism_3.contains_key(&0));
+    assert!(any_set_parallelism_3.contains_key(&1));
+    assert!(any_set_parallelism_3.contains_key(&2));
+    assert_eq!(any_set_parallelism_3[&0], 3);
+    assert_eq!(any_set_parallelism_3[&1], 3);
+    assert_eq!(any_set_parallelism_3[&2], 3);
 }

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -76,6 +76,8 @@ impl ShardingMode {
             dparser::Sharding::All => Self::All,
             dparser::Sharding::Keyed => Self::Key,
             dparser::Sharding::Each => Self::Each,
+            dparser::Sharding::AnyKeyed => Self::AnyKey,
+            dparser::Sharding::AnyEach => Self::AnyEach,
         }
     }
 }

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -197,28 +197,21 @@ impl<'origin> IntoIterator for &'origin CompositionSet {
 /// `AnyEach` and `AnyKey` sets accordingly or use a value of 0 to disable this.
 pub fn get_sharding(
     mut sets: Vec<Option<(ShardingMode, CompositionSet)>>,
-    mut join_order: Vec<usize>,
-    mut join_strategies: Vec<JoinStrategy>,
+    join_order: Vec<usize>,
+    join_strategies: Vec<JoinStrategy>,
     target_parallelism: usize,
 ) -> Vec<Vec<Option<CompositionSet>>> {
     let set_num = sets.len();
-    let mut final_sharding = Vec::new();
+    debug_assert_eq!(join_order.len(), set_num);
+    debug_assert_eq!(
+        join_strategies.len(),
+        if set_num == 0 { 0 } else { set_num - 1 }
+    );
 
+    let mut final_sharding = Vec::new();
     if set_num == 0 {
         return final_sharding;
     }
-
-    // make sure every set is in the order and has a strategy
-    let mut missing_sets: Vec<_> = (0..set_num).map(|index| Some(index)).collect();
-    for index in join_order.iter() {
-        missing_sets[*index] = None;
-    }
-    for missing_index in missing_sets {
-        if let Some(missing) = missing_index {
-            join_order.push(missing);
-        }
-    }
-    join_strategies.resize(set_num - 1, JoinStrategy::Cross);
 
     // first create the iterators for any keyed shardings
     let mut key_join_iter = None;
@@ -374,10 +367,9 @@ pub fn get_sharding(
                 break;
             }
         }
-
-        if let Some(iter) = join_iter.as_mut() {
-            iter.reduce_any_parallelism(any_parallelisms);
-        }
+    }
+    if let Some(iter) = join_iter.as_mut() {
+        iter.reduce_any_parallelism(any_parallelisms);
     }
 
     // generate the sharding sets
@@ -749,7 +741,7 @@ fn join_it_any_chain_test() {
     ];
 
     let join_order = vec![1, 2, 0];
-    let join_strategies = vec![JoinStrategy::Inner];
+    let join_strategies = vec![JoinStrategy::Inner, JoinStrategy::Cross];
 
     let sharding = get_sharding(sets, join_order, join_strategies, 2);
     let expected = vec![
@@ -781,7 +773,7 @@ fn join_it_any_chain_test_1() {
     ];
 
     let join_order = vec![0, 1, 2];
-    let join_strategies = vec![];
+    let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
 
     let sharding_6 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 6);
     assert_eq!(sharding_6.len(), 6); // <- should get 6 shardings
@@ -805,171 +797,194 @@ fn join_it_any_chain_test_1() {
     assert_eq!(sharding_4[0][2].as_ref().unwrap().len(), 1); // <- parallelized set
 }
 
-// #[test]
-// fn any_parallelism_test_2() {
-//     let sets = vec![
-//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1, 2]))),
-//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1]))),
-//     ];
+#[test]
+fn join_it_any_chain_test_2() {
+    let sets = vec![
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1, 2]))),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 1]))),
+    ];
 
-//     let join_order = vec![0, 1];
-//     let join_strategies = vec![JoinStrategy::Cross];
+    let join_order = vec![0, 1];
+    let join_strategies = vec![JoinStrategy::Cross];
 
-//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-//     assert_eq!(any_set_parallelism_2.len(), 1);
-//     assert!(any_set_parallelism_2.contains_key(&1));
-//     assert_eq!(any_set_parallelism_2[&1], 2);
+    let sharding_2 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 2);
+    assert_eq!(sharding_2.len(), 2); // <- should get 2 shardings
+    assert_eq!(sharding_2[0].len(), 2); // <- should still get 2 sets
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().len(), 3);
+    assert_eq!(sharding_2[0][1].as_ref().unwrap().len(), 1); // <- parallelized set
 
-//     let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
-//     assert_eq!(any_set_parallelism_3.len(), 1);
-//     assert!(any_set_parallelism_3.contains_key(&0));
-//     assert_eq!(any_set_parallelism_3[&0], 3);
+    let sharding_3 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 3);
+    assert_eq!(sharding_3.len(), 3); // <- should get 3 shardings
+    assert_eq!(sharding_3[0].len(), 2); // <- should still get 2 sets
+    assert_eq!(sharding_3[0][0].as_ref().unwrap().len(), 1); // <- parallelized set
+    assert_eq!(sharding_3[0][1].as_ref().unwrap().len(), 2);
 
-//     let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
-//     assert_eq!(any_set_parallelism_6.len(), 2);
-//     assert!(any_set_parallelism_6.contains_key(&0));
-//     assert!(any_set_parallelism_6.contains_key(&1));
-//     assert_eq!(any_set_parallelism_6[&0], 3);
-//     assert_eq!(any_set_parallelism_6[&1], 2);
-// }
+    let sharding_6 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 6);
+    assert_eq!(sharding_6.len(), 6); // <- should get 6 shardings
+    assert_eq!(sharding_6[0].len(), 2); // <- should still get 2 sets
+    assert_eq!(sharding_6[0][0].as_ref().unwrap().len(), 1); // <- parallelized set
+    assert_eq!(sharding_6[0][1].as_ref().unwrap().len(), 1); // <- parallelized set
+}
 
-// #[test]
-// fn any_parallelism_test_3() {
-//     let sets = vec![
-//         Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
-//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0, 0]))),
-//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
-//     ];
+#[test]
+fn join_it_any_chain_test_3() {
+    let sets = vec![
+        Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0, 0]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
+    ];
 
-//     let join_order = vec![0, 1, 2];
-//     let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
+    let join_order = vec![0, 1, 2];
+    let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
 
-//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-//     assert_eq!(any_set_parallelism_2.len(), 0);
+    let sharding_2 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 2);
+    assert_eq!(sharding_2.len(), 2); // <- should get 2 shardings
+    assert_eq!(sharding_2[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().len(), 1); // <- always parallelized (not any)
+    assert_eq!(sharding_2[0][1].as_ref().unwrap().len(), 3);
+    assert_eq!(sharding_2[0][2].as_ref().unwrap().len(), 3);
 
-//     let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
-//     assert_eq!(any_set_parallelism_4.len(), 1);
-//     assert!(any_set_parallelism_4.contains_key(&2));
-//     assert_eq!(any_set_parallelism_4[&2], 2);
+    let sharding_4 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 4);
+    assert_eq!(sharding_4.len(), 4); // <- should get 4 shardings
+    assert_eq!(sharding_4[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_4[0][0].as_ref().unwrap().len(), 1); // <- always parallelized (not any)
+    assert_eq!(sharding_4[0][1].as_ref().unwrap().len(), 3);
+    assert_eq!(sharding_4[0][2].as_ref().unwrap().len(), 1); // <- parallelized any set
 
-//     let any_set_parallelism_6 = compute_any_parallelism(&sets, &join_order, &join_strategies, 6);
-//     assert_eq!(any_set_parallelism_6.len(), 1);
-//     assert!(any_set_parallelism_6.contains_key(&1));
-//     assert_eq!(any_set_parallelism_6[&1], 3);
-// }
+    let sharding_6 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 6);
+    assert_eq!(sharding_6.len(), 6); // <- should get 6 shardings
+    assert_eq!(sharding_6[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_6[0][0].as_ref().unwrap().len(), 1); // <- always parallelized (not any)
+    assert_eq!(sharding_6[0][1].as_ref().unwrap().len(), 1); // <- parallelized any set
+    assert_eq!(sharding_6[0][2].as_ref().unwrap().len(), 3);
+}
 
-// #[test]
-// fn any_parallelism_test_4() {
-//     let sets = vec![
-//         Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
-//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
-//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1, 4]))),
-//     ];
+#[test]
+fn join_it_any_chain_test_4() {
+    let sets = vec![
+        Some((ShardingMode::Each, create_dummy_set(vec![0, 0]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1, 4]))),
+    ];
 
-//     let join_order = vec![0, 1, 2];
+    let join_order = vec![1, 2, 0];
 
-//     let join_strategies_inner = vec![JoinStrategy::Cross, JoinStrategy::Inner];
-//     let any_set_parallelism_inner =
-//         compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
-//     assert_eq!(any_set_parallelism_inner.len(), 2);
-//     assert!(any_set_parallelism_inner.contains_key(&1));
-//     assert!(any_set_parallelism_inner.contains_key(&2));
-//     assert_eq!(any_set_parallelism_inner[&1], 2);
-//     assert_eq!(any_set_parallelism_inner[&2], 2);
+    let join_strategies_inner = vec![JoinStrategy::Inner, JoinStrategy::Cross];
+    let sharding_inner = get_sharding(
+        sets.clone(),
+        join_order.clone(),
+        join_strategies_inner.clone(),
+        10,
+    );
+    assert_eq!(sharding_inner.len(), 4); // <- should get 4 shardings
+    assert_eq!(sharding_inner[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_inner[0][0].as_ref().unwrap().len(), 1); // <- always parallelized (not any)
+    assert_eq!(sharding_inner[0][1].as_ref().unwrap().len(), 2); // <- parallelized any set
+    assert_eq!(sharding_inner[0][2].as_ref().unwrap().len(), 1); // <- parallelized any set
 
-//     let join_strategies_left = vec![JoinStrategy::Cross, JoinStrategy::Left];
-//     let any_set_parallelism_left =
-//         compute_any_parallelism(&sets, &join_order, &join_strategies_left, 10);
-//     assert_eq!(any_set_parallelism_left.len(), 2);
-//     assert!(any_set_parallelism_left.contains_key(&1));
-//     assert!(any_set_parallelism_left.contains_key(&2));
-//     assert_eq!(any_set_parallelism_left[&1], 4);
-//     assert_eq!(any_set_parallelism_left[&2], 4);
+    let join_strategies_left = vec![JoinStrategy::Left, JoinStrategy::Cross];
+    let sharding_left = get_sharding(
+        sets.clone(),
+        join_order.clone(),
+        join_strategies_left.clone(),
+        10,
+    );
+    assert_eq!(sharding_left.len(), 8); // <- should get 2*4=8 shardings
+    assert_eq!(sharding_left[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_left[0][0].as_ref().unwrap().len(), 1); // <- always parallelized (not any)
+    assert_eq!(sharding_left[0][1].as_ref().unwrap().len(), 2); // <- parallelized any set
+    assert_eq!(sharding_left[0][2].as_ref().unwrap().len(), 1); // <- parallelized any set
 
-//     let join_strategies_right = vec![JoinStrategy::Cross, JoinStrategy::Right];
-//     let any_set_parallelism_right =
-//         compute_any_parallelism(&sets, &join_order, &join_strategies_right, 10);
-//     assert_eq!(any_set_parallelism_right.len(), 2);
-//     assert!(any_set_parallelism_right.contains_key(&1));
-//     assert!(any_set_parallelism_right.contains_key(&2));
-//     assert_eq!(any_set_parallelism_right[&1], 3);
-//     assert_eq!(any_set_parallelism_right[&2], 3);
+    let join_strategies_right = vec![JoinStrategy::Right, JoinStrategy::Cross];
+    let sharding_right = get_sharding(
+        sets.clone(),
+        join_order.clone(),
+        join_strategies_right.clone(),
+        10,
+    );
+    assert_eq!(sharding_right.len(), 6); // <- should get 2*3=6 shardings
+    assert_eq!(sharding_right[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_right[0][0].as_ref().unwrap().len(), 1); // <- always parallelized (not any)
+    assert_eq!(sharding_right[0][1].as_ref().unwrap().len(), 2); // <- parallelized any set
+    assert_eq!(sharding_right[0][2].as_ref().unwrap().len(), 1); // <- parallelized any set
 
-//     let join_strategies_outer = vec![JoinStrategy::Cross, JoinStrategy::Outer];
-//     let any_set_parallelism_outer =
-//         compute_any_parallelism(&sets, &join_order, &join_strategies_outer, 10);
-//     assert_eq!(any_set_parallelism_outer.len(), 2);
-//     assert!(any_set_parallelism_outer.contains_key(&1));
-//     assert!(any_set_parallelism_outer.contains_key(&2));
-//     assert_eq!(any_set_parallelism_outer[&1], 5);
-//     assert_eq!(any_set_parallelism_outer[&2], 5);
-// }
+    let join_strategies_outer = vec![JoinStrategy::Outer, JoinStrategy::Cross];
+    let sharding_outer = get_sharding(
+        sets.clone(),
+        join_order.clone(),
+        join_strategies_outer.clone(),
+        10,
+    );
+    assert_eq!(sharding_outer.len(), 10); // <- should get 2*5=10 shardings
+    assert_eq!(sharding_outer[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding_outer[0][0].as_ref().unwrap().len(), 1); // <- always parallelized (not any)
+    assert_eq!(sharding_outer[0][1].as_ref().unwrap().len(), 2); // <- parallelized any set
+    assert_eq!(sharding_outer[0][2].as_ref().unwrap().len(), 1); // <- parallelized any set
+}
 
-// #[test]
-// fn any_parallelism_test_5() {
-//     let sets = vec![
-//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 1, 3]))),
-//         Some((ShardingMode::Key, create_dummy_set(vec![0, 1, 1, 4]))),
-//     ];
+#[test]
+fn join_it_any_chain_test_5() {
+    let sets = vec![Some((
+        ShardingMode::AnyKey,
+        create_dummy_set(vec![0, 2, 0, 1, 3]),
+    ))];
 
-//     let join_order = vec![0, 1];
-//     let join_strategies_inner = vec![JoinStrategy::Inner];
+    let join_order = vec![0];
+    let join_strategies = vec![];
 
-//     // if an AnyKey and a Key are joined with a strategy other than cross it is no longer a valid
-//     // any set -> the output should be empty
-//     let any_set_parallelism_inner =
-//         compute_any_parallelism(&sets, &join_order, &join_strategies_inner, 10);
-//     assert_eq!(any_set_parallelism_inner.len(), 0);
-// }
+    let sharding_2 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 2);
+    assert_eq!(sharding_2.len(), 2); // <- should get 2 shardings
+    assert_eq!(sharding_2[0].len(), 1); // <- should still get 1 set
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().len(), 3); // <- parallelized any set
 
-// #[test]
-// fn any_parallelism_test_6() {
-//     let sets = vec![Some((
-//         ShardingMode::AnyKey,
-//         create_dummy_set(vec![0, 2, 0, 1, 3]),
-//     ))];
+    let sharding_4 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 4);
+    assert_eq!(sharding_4.len(), 4); // <- should get 4 shardings
+    assert_eq!(sharding_4[0].len(), 1); // <- should still get 1 set
+    assert_eq!(sharding_4[0][0].as_ref().unwrap().len(), 2); // <- parallelized any set
+}
 
-//     let join_order = vec![0];
-//     let join_strategies = vec![];
+#[test]
+fn join_it_any_chain_test_6() {
+    let sets = vec![
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 4]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 3]))),
+        Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![5, 5]))),
+    ];
 
-//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-//     assert_eq!(any_set_parallelism_2.len(), 1);
-//     assert!(any_set_parallelism_2.contains_key(&0));
-//     assert_eq!(any_set_parallelism_2[&0], 2);
+    let join_order = vec![1, 2, 0, 3];
+    let join_strategies = vec![
+        JoinStrategy::Inner,
+        JoinStrategy::Right,
+        JoinStrategy::Cross,
+    ];
 
-//     let any_set_parallelism_4 = compute_any_parallelism(&sets, &join_order, &join_strategies, 4);
-//     assert_eq!(any_set_parallelism_4.len(), 1);
-//     assert!(any_set_parallelism_4.contains_key(&0));
-//     assert_eq!(any_set_parallelism_4[&0], 4);
-// }
+    let sharding_2 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 2);
+    assert_eq!(sharding_2.len(), 2); // <- should get 2 shardings
+    assert_eq!(sharding_2[0].len(), 4); // <- should still get 4 sets
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().len(), 3);
+    assert_eq!(sharding_2[0][1].as_ref().unwrap().len(), 2);
+    assert_eq!(sharding_2[0][2].as_ref().unwrap().len(), 1);
+    assert_eq!(sharding_2[0][3].as_ref().unwrap().len(), 1); // <- parallelized any set
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[1].0, 1);
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[2].0, 4);
+    assert_eq!(sharding_2[0][1].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding_2[0][1].as_ref().unwrap().item_list[1].0, 0);
+    assert_eq!(sharding_2[0][2].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding_2[0][3].as_ref().unwrap().item_list[0].0, 5);
 
-// #[test]
-// fn any_parallelism_test_7() {
-//     let sets = vec![
-//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 4]))),
-//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 2, 0, 3]))),
-//         Some((ShardingMode::AnyKey, create_dummy_set(vec![0, 1, 1]))),
-//         Some((ShardingMode::AnyEach, create_dummy_set(vec![0, 0]))),
-//     ];
-
-//     let join_order = vec![1, 2, 0, 3];
-//     let join_strategies = vec![
-//         JoinStrategy::Inner,
-//         JoinStrategy::Right,
-//         JoinStrategy::Cross,
-//     ];
-
-//     let any_set_parallelism_2 = compute_any_parallelism(&sets, &join_order, &join_strategies, 2);
-//     assert_eq!(any_set_parallelism_2.len(), 1);
-//     assert!(any_set_parallelism_2.contains_key(&3));
-//     assert_eq!(any_set_parallelism_2[&3], 2);
-
-//     let any_set_parallelism_3 = compute_any_parallelism(&sets, &join_order, &join_strategies, 3);
-//     assert_eq!(any_set_parallelism_3.len(), 3);
-//     assert!(any_set_parallelism_3.contains_key(&0));
-//     assert!(any_set_parallelism_3.contains_key(&1));
-//     assert!(any_set_parallelism_3.contains_key(&2));
-//     assert_eq!(any_set_parallelism_3[&0], 3);
-//     assert_eq!(any_set_parallelism_3[&1], 3);
-//     assert_eq!(any_set_parallelism_3[&2], 3);
-// }
+    let sharding_3 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 3);
+    assert_eq!(sharding_3.len(), 3); // <- should get 3 shardings
+    assert_eq!(sharding_3[0].len(), 4); // <- should still get 4 sets
+    assert_eq!(sharding_3[0][0].as_ref().unwrap().len(), 1); // <- parallelized any set
+    assert_eq!(sharding_3[0][1].as_ref().unwrap().len(), 2); // <- parallelized any set
+    assert_eq!(sharding_3[0][2].as_ref().unwrap().len(), 1); // <- parallelized any set
+    assert_eq!(sharding_3[0][3].as_ref().unwrap().len(), 2);
+    assert_eq!(sharding_3[0][0].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding_3[0][1].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding_3[0][1].as_ref().unwrap().item_list[1].0, 0);
+    assert_eq!(sharding_3[0][2].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[0].0, 5);
+    assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[1].0, 5);
+}

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -140,31 +140,6 @@ impl CompositionSet {
         (context_item.ident.clone(), context_item.key, data_bytes)
     }
 
-    // TODO: we are just slicing a vec, should be able to do this via slice references or iters instead of Vecs
-    pub fn shard(self, mode: ShardingMode) -> Vec<CompositionSet> {
-        return match mode {
-            ShardingMode::All => {
-                vec![self]
-            }
-            ShardingMode::Key | ShardingMode::AnyKey => self
-                .item_list
-                .chunk_by(|(key_a, _, _), (key_b, _, _)| key_a == key_b)
-                .map(|new_item_list| CompositionSet {
-                    item_list: new_item_list.to_vec(),
-                    set_index: self.set_index,
-                })
-                .collect(),
-            ShardingMode::Each | ShardingMode::AnyEach => self
-                .item_list
-                .into_iter()
-                .map(|item| CompositionSet {
-                    item_list: vec![item],
-                    set_index: self.set_index,
-                })
-                .collect(),
-        };
-    }
-
     pub fn combine(&mut self, additional: CompositionSet) -> DandelionResult<()> {
         let CompositionSet {
             item_list,

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -304,7 +304,7 @@ pub fn get_sharding(
                         vec![set_idx],
                         sharding,
                     );
-                    if any_join_iter.is_some() {
+                    if max_parallelism > 0 {
                         any_parallelisms.push((max_parallelism, 1, false));
                     }
                     join_iter = any_join_iter.map(|i| i as Box<dyn JoinIterator>);
@@ -338,7 +338,7 @@ pub fn get_sharding(
                         joined_set_idcs,
                         sharding,
                     );
-                    if any_join_iter.is_some() {
+                    if max_parallelism > 0 {
                         any_parallelisms.push((max_parallelism, 1, false));
                     }
                     join_iter = any_join_iter.map(|i| i as Box<dyn JoinIterator>);

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -2,9 +2,11 @@ use crate::{
     composition::join_iterator::JoinIterator,
     memory_domain::{Context, ContextTrait},
 };
+use core::fmt;
 use dandelion_commons::{
     err_dandelion, DandelionError, DandelionResult, DispatcherError, FunctionId,
 };
+use log::trace;
 use std::{cmp, collections::BTreeMap, sync::Arc, vec};
 
 #[cfg(test)]
@@ -191,6 +193,21 @@ impl<'origin> IntoIterator for &'origin CompositionSet {
     }
 }
 
+/// A more concise display for the composition set that does not print the entire Context contents.
+impl fmt::Display for CompositionSet {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "item_index: [")?;
+        for (key, itm_idx, ctx) in self.item_list.iter() {
+            write!(
+                f,
+                "(key: {}, idx: {}, context: {{ type: {:?}, size: {}, state: {:?} }})",
+                key, itm_idx, ctx.context, ctx.size, ctx.state
+            )?;
+        }
+        write!(f, "], set_index: {}", self.set_index)
+    }
+}
+
 /// Computes the sharding for the given sets following the given join order and join strategies.
 /// The `join_order` vector is expected to be of length `sets.len()`, the `join_strategies` vector
 /// is expected to be of size `sets.len() - 1`.
@@ -210,8 +227,15 @@ pub fn get_sharding(
         if set_num == 0 { 0 } else { set_num - 1 }
     );
 
+    trace!(
+        "Computing sharding using sets: {:?}, join_order: {:?}, join_strategies: {:?}.",
+        sets,
+        join_order,
+        join_strategies
+    );
     let mut final_sharding = Vec::new();
     if set_num == 0 {
+        trace!("Found empty sharding.");
         return final_sharding;
     }
 
@@ -257,7 +281,7 @@ pub fn get_sharding(
     }
 
     // second create the iterators for all remaining shardings
-    let mut any_parallelisms: Vec<(usize, usize)> = Vec::new(); // vec of (max parallelism, chosen parallelism)
+    let mut any_parallelisms: Vec<(usize, usize, bool)> = Vec::new(); // vec of (max parallelism, chosen parallelism)
     let mut join_iter = key_join_iter.map(|i| i as Box<dyn JoinIterator>);
     while i < join_order.len() {
         let set_idx = join_order[i];
@@ -281,7 +305,7 @@ pub fn get_sharding(
                         sharding,
                     );
                     if any_join_iter.is_some() {
-                        any_parallelisms.push((max_parallelism, 1));
+                        any_parallelisms.push((max_parallelism, 1, false));
                     }
                     join_iter = any_join_iter.map(|i| i as Box<dyn JoinIterator>);
                 }
@@ -315,7 +339,7 @@ pub fn get_sharding(
                         sharding,
                     );
                     if any_join_iter.is_some() {
-                        any_parallelisms.push((max_parallelism, 1));
+                        any_parallelisms.push((max_parallelism, 1, false));
                     }
                     join_iter = any_join_iter.map(|i| i as Box<dyn JoinIterator>);
                 }
@@ -326,6 +350,11 @@ pub fn get_sharding(
         }
         i += 1;
     }
+    trace!(
+        "Found fixed_parallelism: {} (target_parallelism: {}",
+        fixed_parallelism,
+        target_parallelism
+    );
 
     // compute the parallelism for the any shardings
     if fixed_parallelism < target_parallelism && !any_parallelisms.is_empty() {
@@ -334,9 +363,9 @@ pub fn get_sharding(
             // find the best suitable set to parallelize over
             let mut best_idx = 0;
             let mut best_dist = 0.0;
-            for (i, (max_p, chosen_p)) in any_parallelisms.iter().enumerate() {
+            for (i, (max_p, _, processed)) in any_parallelisms.iter().enumerate() {
                 // check that we have not yet assigned a parallelism to this any set
-                if *chosen_p == 1 {
+                if !*processed {
                     let remainder = max_p % leftover_parallelism;
                     if remainder == 0 {
                         best_idx = i;
@@ -360,8 +389,9 @@ pub fn get_sharding(
                 if leftover_parallelism <= 1 {
                     break;
                 }
+                any_parallelisms[best_idx].2 = true;
             } else {
-                if any_parallelisms[best_idx].1 == 1 {
+                if !any_parallelisms[best_idx].2 {
                     let chosen_parallelism =
                         cmp::min(leftover_parallelism, any_parallelisms[best_idx].0);
                     any_parallelisms[best_idx].1 = chosen_parallelism;
@@ -371,6 +401,7 @@ pub fn get_sharding(
         }
     }
     if target_parallelism > 0 {
+        trace!("Using any parallelism: {:?}", any_parallelisms);
         if let Some(iter) = join_iter.as_mut() {
             iter.reduce_any_parallelism(any_parallelisms);
         }
@@ -390,6 +421,7 @@ pub fn get_sharding(
         }
     }
 
+    trace!("Computed sharding: {:?}", final_sharding);
     final_sharding
 }
 
@@ -991,4 +1023,30 @@ fn join_it_any_chain_test_6() {
     assert_eq!(sharding_3[0][2].as_ref().unwrap().item_list[0].0, 0);
     assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[0].0, 5);
     assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[1].0, 5);
+}
+
+#[test]
+fn join_it_any_chain_test_7() {
+    let sets = vec![
+        Some((ShardingMode::Each, create_dummy_set(vec![0]))),
+        Some((ShardingMode::AnyEach, create_dummy_set(vec![0]))),
+        None,
+    ];
+
+    let join_order = vec![0, 1, 2];
+    let join_strategies = vec![JoinStrategy::Cross, JoinStrategy::Cross];
+
+    let sharding = get_sharding(
+        sets.clone(),
+        join_order.clone(),
+        join_strategies.clone(),
+        usize::MAX,
+    );
+    assert_eq!(sharding.len(), 1); // <- should get 1 sharding
+    assert_eq!(sharding[0].len(), 3); // <- should still get 3 sets
+    assert_eq!(sharding[0][0].as_ref().unwrap().len(), 1);
+    assert_eq!(sharding[0][1].as_ref().unwrap().len(), 1);
+    assert!(sharding[0][2].is_none());
+    assert_eq!(sharding[0][0].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding[0][1].as_ref().unwrap().item_list[0].0, 0);
 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -221,11 +221,14 @@ impl SetKeyIterator {
 impl JoinIterator for SetKeyIterator {
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
         debug_assert!(self.key_groups_idx < self.key_groups.len());
-        debug_assert!(self.key == self.key_groups[self.key_groups_idx].0);
-        to_fill[self.write_idx] = Some(CompositionSet {
-            item_list: self.set.item_list[self.key_groups[self.key_groups_idx].1.clone()].to_vec(),
-            set_index: self.set.set_index,
-        });
+        let fill_this_set = self.key == self.key_groups[self.key_groups_idx].0;
+        if fill_this_set {
+            to_fill[self.write_idx] = Some(CompositionSet {
+                item_list: self.set.item_list[self.key_groups[self.key_groups_idx].1.clone()]
+                    .to_vec(),
+                set_index: self.set.set_index,
+            });
+        }
         if let Some(left) = &mut self.left {
             match self.strategy {
                 // modes for which always want left to fill in
@@ -237,10 +240,14 @@ impl JoinIterator for SetKeyIterator {
                     }
                 }
                 // Only want left to fill if this iterator has filled something in
-                JoinStrategy::Inner => left.fill_in(to_fill),
+                JoinStrategy::Inner => {
+                    if fill_this_set {
+                        left.fill_in(to_fill)
+                    }
+                }
                 // Only want left to fill if this iterator has filled and the keys match
                 JoinStrategy::Right => {
-                    if self.key == left.get_key() {
+                    if fill_this_set && self.key == left.get_key() {
                         left.fill_in(to_fill)
                     }
                 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -206,6 +206,8 @@ fn key_set_union(curr_keys: &mut Vec<u32>, new_key_groups: &Vec<(u32, Range<usiz
 }
 
 impl SetKeyIterator {
+    /// Computes the key_groups (index ranges) that combine all items with the same key and sets the
+    /// index to the first valid element based on the join strategy.
     pub(super) fn new(
         mut left: Option<Box<SetKeyIterator>>,
         set: CompositionSet,
@@ -305,8 +307,11 @@ impl JoinIterator for SetKeyIterator {
     }
 
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-        debug_assert!(self.key_groups_idx < self.key_groups.len());
-        let fill_this_set = self.key == self.key_groups[self.key_groups_idx].0;
+        // NOTE: for this iterator `self.key_groups_idx` may be equals to `self.key_groups.len()`
+        //       (e.g. a right join might advance the left to this point if there is no matching
+        //       left key for the right one)
+        let fill_this_set = self.key_groups_idx < self.key_groups.len()
+            && self.key == self.key_groups[self.key_groups_idx].0;
         if fill_this_set {
             to_fill[self.write_idx] = Some(CompositionSet {
                 item_list: self.set.item_list[self.key_groups[self.key_groups_idx].1.clone()]
@@ -318,19 +323,19 @@ impl JoinIterator for SetKeyIterator {
             match self.strategy {
                 // modes for which always want left to fill in
                 JoinStrategy::Cross | JoinStrategy::Left => left.fill_in(to_fill),
-                // Only want to fill left if it is the one with the current key
+                // only want to fill left if it is the one with the current key
                 JoinStrategy::Outer => {
                     if self.key == left.key {
                         left.fill_in(to_fill)
                     }
                 }
-                // Only want left to fill if this iterator has filled something in
+                // only want left to fill if this iterator has filled something in
                 JoinStrategy::Inner => {
                     if fill_this_set {
                         left.fill_in(to_fill)
                     }
                 }
-                // Only want left to fill if this iterator has filled and the keys match
+                // only want left to fill if this iterator has filled and the keys match
                 JoinStrategy::Right => {
                     if fill_this_set && self.key == left.key {
                         left.fill_in(to_fill)
@@ -395,11 +400,11 @@ impl JoinIterator for SetKeyIterator {
                     }
                 }
                 JoinStrategy::Right => {
-                    if self.key_groups_idx + 1 >= self.key_groups.len() {
+                    self.key_groups_idx += 1;
+                    if self.key_groups_idx >= self.key_groups.len() {
                         self.key_groups_idx = self.key_groups.len();
                         return false;
                     }
-                    self.key_groups_idx += 1;
                     self.key = self.key_groups[self.key_groups_idx].0;
                     while self.key > left.key {
                         if !left.advance() {
@@ -516,6 +521,11 @@ impl JoinIterator for SetKeyIterator {
 
 /// Implements the JoinIterator for the `any` shardings. This could be a single `AnyEach` sharding
 /// or a chain of joined `AnyKey` shardings.
+///
+/// Under the hood we first generate all sets using the `SetEachIterator` or `SetKeyIterators` and
+/// save them in the `set_groups`. Once we know the degree to which this any sharding should be
+/// parallelized we combine the sets into equally distributed groups using the
+/// `reduce_any_parallelism` function.
 ///
 /// NOTE: The `AnyIterator` assumes none of its sets that are cross-joined. For two cross-joined
 ///       `any` sets create two separate `AnyIterator` instances, one for each of the sets.

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -1,20 +1,29 @@
 use crate::composition::{CompositionSet, JoinStrategy, ShardingMode};
 
-trait JoinIterator {
+pub(super) trait JoinIterator {
+    /// Fills the given composition set vector with the current iterator state.
+    /// This is undefined behaviour if the previous `advance` call returned `false`.
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>);
+
+    /// Advances the iterator by one.
+    /// An `advance` call following an `advance` that returned `false` always returns `false`.
+    /// A `fill_in` call after an `advance` that called `false` is undefined behaviour.
     fn advance(&mut self) -> bool;
+
+    /// Used to get the key from the left iterator for joining operations. Only supported by the
+    /// `SetKeyIterator` and panics otherwise.
     fn get_key(&self) -> u32;
 }
 
 /// Implements the JoinIterator for the `all` sharding.
-struct SetAllIterator {
+pub(super) struct SetAllIterator {
     left: Option<Box<dyn JoinIterator>>,
     set: CompositionSet,
     write_idx: usize,
 }
 
 impl SetAllIterator {
-    fn new(
+    pub(super) fn new(
         left: Option<Box<dyn JoinIterator>>,
         set: CompositionSet,
         write_idx: usize,
@@ -53,7 +62,7 @@ impl JoinIterator for SetAllIterator {
 }
 
 /// Implements the JoinIterator for the `each` sharding.
-struct SetEachIterator {
+pub(super) struct SetEachIterator {
     left: Option<Box<dyn JoinIterator>>,
     sets: Vec<CompositionSet>,
     sets_idx: usize,
@@ -61,7 +70,7 @@ struct SetEachIterator {
 }
 
 impl SetEachIterator {
-    fn new(
+    pub(super) fn new(
         left: Option<Box<dyn JoinIterator>>,
         set: CompositionSet,
         write_idx: usize,
@@ -116,7 +125,7 @@ impl JoinIterator for SetEachIterator {
 }
 
 /// Implements the JoinIterator for the `keyed` sharding.
-struct SetKeyIterator {
+pub(super) struct SetKeyIterator {
     left: Option<Box<dyn JoinIterator>>,
     sets: Vec<CompositionSet>,
     sets_idx: usize,
@@ -126,7 +135,7 @@ struct SetKeyIterator {
 }
 
 impl SetKeyIterator {
-    fn new(
+    pub(super) fn new(
         mut left: Option<Box<dyn JoinIterator>>,
         set: CompositionSet,
         strategy: JoinStrategy,
@@ -323,7 +332,7 @@ impl JoinIterator for SetKeyIterator {
                             self.key =
                                 u32::min(self.sets[self.sets_idx].item_list[0].0, left.get_key());
                         } else {
-                            //  left did not advance, so set key to current right key
+                            // left did not advance, so set key to current right key
                             self.key = current_self_key;
                         }
                         true
@@ -410,8 +419,9 @@ impl JoinIterator for SetKeyIterator {
     }
 }
 
-/// Implements the JoinIterator for the `any` shardings.
-struct AnyIterator {
+/// Implements the JoinIterator for the `any` shardings. This could be a single `AnyEach`/`AnyKey`
+/// sharding or a chain of joined `AnyKey` shardings.
+pub(super) struct AnyIterator {
     left: Option<Box<dyn JoinIterator>>,
     set_groups: Vec<Vec<Option<CompositionSet>>>,
     set_groups_idx: usize,
@@ -419,7 +429,7 @@ struct AnyIterator {
 }
 
 impl AnyIterator {
-    fn new(
+    pub(super) fn new(
         left: Option<Box<dyn JoinIterator>>,
         sets: Vec<CompositionSet>,
         strategies: Vec<JoinStrategy>,

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -3,6 +3,11 @@ use std::ops::Range;
 use crate::composition::{CompositionSet, JoinStrategy, ShardingMode};
 
 pub(super) trait JoinIterator {
+    /// Reduces the parallelism of all `AnyIterators` in the iterator chain by combining some sets.
+    /// We expect this function is only called once, otherwise, we could end up with unevenly
+    /// distributed or completely messed up groups.
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>);
+
     /// Fills the given composition set vector with the current iterator state.
     /// This is undefined behaviour if the previous `advance` call returned `false`.
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>);
@@ -11,10 +16,6 @@ pub(super) trait JoinIterator {
     /// An `advance` call following an `advance` that returned `false` always returns `false`.
     /// A `fill_in` call after an `advance` that called `false` is undefined behaviour.
     fn advance(&mut self) -> bool;
-
-    /// Used to get the key from the left iterator for joining operations. Only supported by the
-    /// `SetKeyIterator` and panics otherwise.
-    fn get_key(&self) -> u32;
 }
 
 /// Implements the JoinIterator for the `all` sharding.
@@ -43,6 +44,14 @@ impl SetAllIterator {
 }
 
 impl JoinIterator for SetAllIterator {
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>) {
+        if let Some(left) = self.left.as_mut() {
+            left.reduce_any_parallelism(any_parallelisms);
+        } else {
+            debug_assert!(any_parallelisms.len() == 0);
+        }
+    }
+
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
         to_fill[self.write_idx] = Some(self.set.clone());
         if let Some(left) = &mut self.left {
@@ -56,10 +65,6 @@ impl JoinIterator for SetAllIterator {
         } else {
             false
         }
-    }
-
-    fn get_key(&self) -> u32 {
-        panic!("get_key should not be called on SetAllIterator.");
     }
 }
 
@@ -76,21 +81,31 @@ impl SetEachIterator {
         left: Option<Box<dyn JoinIterator>>,
         set: CompositionSet,
         write_idx: usize,
-    ) -> Option<Box<dyn JoinIterator>> {
+    ) -> (Option<Box<dyn JoinIterator>>, usize) {
         if set.is_empty() {
-            return left;
+            return (left, 1);
         }
 
-        Some(Box::new(Self {
+        let num_items = set.len();
+        let it: Option<Box<dyn JoinIterator>> = Some(Box::new(Self {
             left,
             set,
             item_idx: 0,
             write_idx,
-        }))
+        }));
+        (it, num_items)
     }
 }
 
 impl JoinIterator for SetEachIterator {
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>) {
+        if let Some(left) = self.left.as_mut() {
+            left.reduce_any_parallelism(any_parallelisms);
+        } else {
+            debug_assert!(any_parallelisms.len() == 0);
+        }
+    }
+
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
         debug_assert!(self.item_idx < self.set.item_list.len());
         to_fill[self.write_idx] = Some(CompositionSet {
@@ -121,15 +136,15 @@ impl JoinIterator for SetEachIterator {
             }
         }
     }
-
-    fn get_key(&self) -> u32 {
-        panic!("get_key should not be called on SetEachIterator.");
-    }
 }
 
 /// Implements the JoinIterator for the `keyed` sharding.
+///
+/// NOTE: We assume all `key`/`anyKey` sharded sets to precede all other sharded sets in the join
+///       order. As a result, the `SetKeyIterator` takes a reference another `SetKeyIterator` for
+///       the left instead of a more general `JoinIterator`.
 pub(super) struct SetKeyIterator {
-    left: Option<Box<dyn JoinIterator>>,
+    left: Option<Box<SetKeyIterator>>,
     set: CompositionSet,
     key_groups: Vec<(u32, Range<usize>)>,
     key_groups_idx: usize,
@@ -138,13 +153,66 @@ pub(super) struct SetKeyIterator {
     write_idx: usize,
 }
 
+fn key_set_intersect(curr_keys: &mut Vec<u32>, new_key_groups: &Vec<(u32, Range<usize>)>) {
+    let mut write_idx = 0;
+    let mut j = 0;
+
+    for i in 0..curr_keys.len() {
+        let val = curr_keys[i];
+        while j < new_key_groups.len() && new_key_groups[j].0 < val {
+            j += 1;
+        }
+
+        if j < new_key_groups.len() && new_key_groups[j].0 == val {
+            curr_keys[write_idx] = val;
+            write_idx += 1;
+            j += 1;
+        }
+    }
+
+    curr_keys.truncate(write_idx);
+}
+
+fn key_set_union(curr_keys: &mut Vec<u32>, new_key_groups: &Vec<(u32, Range<usize>)>) {
+    if new_key_groups.len() == 0 {
+        return;
+    } else if curr_keys.len() == 0 {
+        return *curr_keys = new_key_groups.iter().map(|(k, _)| *k).collect();
+    }
+
+    // using a new vector is more compute efficient but uses more memory than doing it in-place
+    let mut result = Vec::with_capacity(curr_keys.len() + new_key_groups.len());
+    let (mut i, mut j) = (0, 0);
+
+    while i < curr_keys.len() && j < new_key_groups.len() {
+        if curr_keys[i] < new_key_groups[j].0 {
+            result.push(curr_keys[i]);
+            i += 1;
+        } else if curr_keys[i] > new_key_groups[j].0 {
+            result.push(new_key_groups[j].0);
+            j += 1;
+        } else {
+            result.push(curr_keys[i]);
+            i += 1;
+            j += 1;
+        }
+    }
+
+    // push remaining elements from whichever vec isn't empty
+    result.extend_from_slice(&curr_keys[i..]);
+    result.extend(new_key_groups.iter().skip(j).map(|(k, _)| k));
+
+    *curr_keys = result;
+}
+
 impl SetKeyIterator {
     pub(super) fn new(
-        mut left: Option<Box<dyn JoinIterator>>,
+        mut left: Option<Box<SetKeyIterator>>,
         set: CompositionSet,
         strategy: JoinStrategy,
         write_idx: usize,
-    ) -> Option<Box<dyn JoinIterator>> {
+        join_group_key_set: &mut Vec<u32>,
+    ) -> Option<Box<SetKeyIterator>> {
         let mut key_groups = Vec::new();
         let mut start_idx = 0;
         for chunk in set.item_list.chunk_by(|a, b| a.0 == b.0) {
@@ -153,7 +221,13 @@ impl SetKeyIterator {
             key_groups.push((key, start_idx..end_idx));
             start_idx = end_idx;
         }
+
+        // handle empty set
         if key_groups.is_empty() {
+            match strategy {
+                JoinStrategy::Left | JoinStrategy::Outer => (),
+                _ => join_group_key_set.clear(),
+            };
             return left;
         }
 
@@ -162,8 +236,10 @@ impl SetKeyIterator {
         if let Some(left_it) = &mut left {
             match strategy {
                 JoinStrategy::Inner => {
-                    while key_groups_idx < key_groups.len() && key != left_it.get_key() {
-                        if key < left_it.get_key() {
+                    key_set_intersect(join_group_key_set, &key_groups);
+
+                    while key_groups_idx < key_groups.len() && key != left_it.key {
+                        if key < left_it.key {
                             key_groups_idx += 1;
                             if key_groups_idx < key_groups.len() {
                                 key = key_groups[key_groups_idx].0;
@@ -179,30 +255,35 @@ impl SetKeyIterator {
                     }
                 }
                 JoinStrategy::Left => {
+                    // -> join_group_key_set remains the same
                     while key_groups_idx < key_groups.len()
-                        && key_groups[key_groups_idx].0 < left_it.get_key()
+                        && key_groups[key_groups_idx].0 < left_it.key
                     {
                         key_groups_idx += 1;
                     }
-                    key = left_it.get_key();
+                    key = left_it.key;
                     if key_groups_idx == key_groups.len() {
                         return left;
                     }
                 }
                 JoinStrategy::Outer => {
-                    if left_it.get_key() < key {
-                        key = left_it.get_key();
+                    key_set_union(join_group_key_set, &key_groups);
+                    if left_it.key < key {
+                        key = left_it.key;
                     }
-                    // else already has the correct key set
                 }
-                JoinStrategy::Right | JoinStrategy::Cross => (),
+                JoinStrategy::Right | JoinStrategy::Cross => {
+                    *join_group_key_set = key_groups.iter().map(|(k, _)| *k).collect()
+                    // -> already has the correct key set
+                }
             }
         } else {
             match strategy {
                 JoinStrategy::Inner | JoinStrategy::Left => {
+                    join_group_key_set.clear();
                     return None;
                 }
-                _ => (),
+                _ => *join_group_key_set = key_groups.iter().map(|(k, _)| *k).collect(),
             }
         }
 
@@ -219,6 +300,10 @@ impl SetKeyIterator {
 }
 
 impl JoinIterator for SetKeyIterator {
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>) {
+        debug_assert!(any_parallelisms.len() == 0);
+    }
+
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
         debug_assert!(self.key_groups_idx < self.key_groups.len());
         let fill_this_set = self.key == self.key_groups[self.key_groups_idx].0;
@@ -235,7 +320,7 @@ impl JoinIterator for SetKeyIterator {
                 JoinStrategy::Cross | JoinStrategy::Left => left.fill_in(to_fill),
                 // Only want to fill left if it is the one with the current key
                 JoinStrategy::Outer => {
-                    if self.key == left.get_key() {
+                    if self.key == left.key {
                         left.fill_in(to_fill)
                     }
                 }
@@ -247,7 +332,7 @@ impl JoinIterator for SetKeyIterator {
                 }
                 // Only want left to fill if this iterator has filled and the keys match
                 JoinStrategy::Right => {
-                    if fill_this_set && self.key == left.get_key() {
+                    if fill_this_set && self.key == left.key {
                         left.fill_in(to_fill)
                     }
                 }
@@ -272,14 +357,14 @@ impl JoinIterator for SetKeyIterator {
                         return false;
                     }
                     self.key = self.key_groups[self.key_groups_idx].0;
-                    while self.key != left.get_key() {
-                        if self.key > left.get_key() {
+                    while self.key != left.key {
+                        if self.key > left.key {
                             if !left.advance() {
                                 self.key_groups_idx = self.key_groups.len();
                                 return false;
                             }
                         // need to advance right and are able to do so
-                        } else if self.key < left.get_key() {
+                        } else if self.key < left.key {
                             self.key_groups_idx += 1;
                             if self.key_groups_idx >= self.key_groups.len() {
                                 self.key_groups_idx = self.key_groups.len();
@@ -295,14 +380,14 @@ impl JoinIterator for SetKeyIterator {
                     // advance left and see if we can match
                     if left.advance() {
                         while self.key_groups_idx + 1 < self.key_groups.len()
-                            && self.key_groups[self.key_groups_idx].0 < left.get_key()
+                            && self.key_groups[self.key_groups_idx].0 < left.key
                         {
                             self.key_groups_idx += 1;
                         }
                         // after this the key is guaranteed to be equal to the left key or bigger
                         // so if the keys match that will be fine for copy in, otherwise this will be skipped
                         // if the key already equal or bigger, it was not advanced
-                        self.key = left.get_key();
+                        self.key = left.key;
                         true
                     } else {
                         self.key_groups_idx = self.key_groups.len();
@@ -316,7 +401,7 @@ impl JoinIterator for SetKeyIterator {
                     }
                     self.key_groups_idx += 1;
                     self.key = self.key_groups[self.key_groups_idx].0;
-                    while self.key > left.get_key() {
+                    while self.key > left.key {
                         if !left.advance() {
                             break;
                         }
@@ -327,34 +412,32 @@ impl JoinIterator for SetKeyIterator {
                     let current_self_key = self.key_groups[self.key_groups_idx].0;
                     let right_can_be_advanced = self.key_groups_idx + 1 < self.key_groups.len();
                     // check if one of the already known keys is bigger, if so we know we can adavance
-                    if self.key < left.get_key() {
+                    if self.key < left.key {
                         // last key was set from right, since left is bigger
                         debug_assert_eq!(self.key, current_self_key);
                         // if right can be advance it should be advanced, otherwise just set key to left one
                         if right_can_be_advanced {
                             self.key_groups_idx += 1;
                             // new right might still be smaller than left key
-                            self.key =
-                                u32::min(self.key_groups[self.key_groups_idx].0, left.get_key());
+                            self.key = u32::min(self.key_groups[self.key_groups_idx].0, left.key);
                         } else {
-                            self.key = left.get_key();
+                            self.key = left.key;
                         }
                         true
                     } else if self.key < current_self_key {
                         // the last key was set from left, since right is bigger
-                        debug_assert_eq!(self.key, left.get_key());
+                        debug_assert_eq!(self.key, left.key);
                         // if left can be advanced it should be, if not move
                         if left.advance() {
                             // new left key might still be smaller than right
-                            self.key =
-                                u32::min(self.key_groups[self.key_groups_idx].0, left.get_key());
+                            self.key = u32::min(self.key_groups[self.key_groups_idx].0, left.key);
                         } else {
                             // left did not advance, so set key to current right key
                             self.key = current_self_key;
                             self.left = None; // asserts that left.advance() is not called again
                         }
                         true
-                    } else if self.key == left.get_key() && self.key == current_self_key {
+                    } else if self.key == left.key && self.key == current_self_key {
                         // both keys are the same, so advance any that are possible to advance and take new key from there
                         let left_advance_success = left.advance();
                         if right_can_be_advanced {
@@ -362,10 +445,8 @@ impl JoinIterator for SetKeyIterator {
                         }
                         match (right_can_be_advanced, left_advance_success) {
                             (true, true) => {
-                                self.key = u32::min(
-                                    self.key_groups[self.key_groups_idx].0,
-                                    left.get_key(),
-                                );
+                                self.key =
+                                    u32::min(self.key_groups[self.key_groups_idx].0, left.key);
                                 true
                             }
                             (true, false) => {
@@ -373,7 +454,7 @@ impl JoinIterator for SetKeyIterator {
                                 true
                             }
                             (false, true) => {
-                                self.key = left.get_key();
+                                self.key = left.key;
                                 true
                             }
                             (false, false) => {
@@ -383,9 +464,9 @@ impl JoinIterator for SetKeyIterator {
                         }
                     } else {
                         // the key is already set to the bigger of the two current keys, try to advance that one
-                        if current_self_key == left.get_key() {
+                        if current_self_key == left.key {
                             let did_advance = left.advance();
-                            self.key = left.get_key();
+                            self.key = left.key;
                             did_advance
                         } else {
                             if right_can_be_advanced {
@@ -431,14 +512,13 @@ impl JoinIterator for SetKeyIterator {
             }
         }
     }
-
-    fn get_key(&self) -> u32 {
-        self.key
-    }
 }
 
-/// Implements the JoinIterator for the `any` shardings. This could be a single `AnyEach`/`AnyKey`
-/// sharding or a chain of joined `AnyKey` shardings.
+/// Implements the JoinIterator for the `any` shardings. This could be a single `AnyEach` sharding
+/// or a chain of joined `AnyKey` shardings.
+///
+/// NOTE: The `AnyIterator` assumes none of its sets that are cross-joined. For two cross-joined
+///       `any` sets create two separate `AnyIterator` instances, one for each of the sets.
 pub(super) struct AnyIterator {
     left: Option<Box<dyn JoinIterator>>,
     set_groups: Vec<Vec<Option<CompositionSet>>>,
@@ -452,26 +532,30 @@ impl AnyIterator {
         sets: Vec<CompositionSet>,
         strategies: Vec<JoinStrategy>,
         write_idcs: Vec<usize>,
-        num_groups: usize,
         sharding: ShardingMode,
-    ) -> Option<Box<dyn JoinIterator>> {
-        debug_assert!(num_groups > 1); // for one group directly use a SetAllIterator
+    ) -> (Option<Box<AnyIterator>>, usize) {
         let num_sets = sets.len();
+        debug_assert!(num_sets > 0);
 
         // build the iterators to generate all sets so we can then group them
         let mut inner_join_it = None;
-        for (i, set) in sets.into_iter().enumerate() {
-            if sharding == ShardingMode::AnyEach {
-                inner_join_it = SetEachIterator::new(inner_join_it, set, i);
-            } else {
-                debug_assert!(sharding == ShardingMode::AnyKey);
+        if sharding == ShardingMode::AnyEach {
+            debug_assert_eq!(num_sets, 1);
+            (inner_join_it, _) =
+                SetEachIterator::new(inner_join_it, sets.into_iter().next().unwrap(), 0);
+        } else {
+            debug_assert_eq!(sharding, ShardingMode::AnyKey);
+            let mut inner_key_it = None;
+            for (i, set) in sets.into_iter().enumerate() {
                 let strategy = if i > 0 {
                     strategies[i - 1]
                 } else {
                     JoinStrategy::Cross
                 };
-                inner_join_it = SetKeyIterator::new(inner_join_it, set, strategy, i);
+                let mut empty: Vec<u32> = vec![]; // can ignore join key set
+                inner_key_it = SetKeyIterator::new(inner_key_it, set, strategy, i, &mut empty);
             }
+            inner_join_it = inner_key_it.map(|i| i as Box<dyn JoinIterator>);
         }
 
         if let Some(mut it) = inner_join_it {
@@ -488,53 +572,74 @@ impl AnyIterator {
                 it.fill_in(&mut next_sets);
                 inner_sharding.push(next_sets);
             }
+            let max_parallelism = inner_sharding.len();
 
-            // split them into even groups
-            let mut set_groups = Vec::with_capacity(num_groups);
-            let base_size = inner_sharding.len() / num_groups;
-            let remainder = inner_sharding.len() % num_groups;
-            let mut start_idx = 0;
-            for group_idx in 0..num_groups {
-                let extra = if group_idx < remainder { 1 } else { 0 };
-                let end_idx = start_idx + base_size + extra;
-
-                let mut set_group = Vec::with_capacity(num_sets);
-                for set_idx in 0..num_sets {
-                    let mut curr_set: Option<CompositionSet> = None;
-                    for i in start_idx..end_idx {
-                        if let Some(set) = &mut curr_set {
-                            if let Some(next_set) = inner_sharding[i][set_idx].take() {
-                                set.combine(next_set).unwrap();
-                            }
-                        } else {
-                            curr_set = inner_sharding[i][set_idx].take();
-                        }
-                    }
-                    set_group.push(curr_set);
-                }
-                set_groups.push(set_group);
-                start_idx = end_idx;
-            }
-
-            Some(Box::new(Self {
-                left,
-                set_groups,
-                set_groups_idx: 0,
-                write_idcs,
-            }))
+            (
+                Some(Box::new(Self {
+                    left,
+                    set_groups: inner_sharding,
+                    set_groups_idx: 0,
+                    write_idcs,
+                })),
+                max_parallelism,
+            )
         } else {
             // we failed to build the inner join iterators...
-            None
+            (None, 0)
         }
     }
 }
 
 impl JoinIterator for AnyIterator {
+    fn reduce_any_parallelism(&mut self, mut any_parallelisms: Vec<(usize, usize)>) {
+        let (_, parallelism) = any_parallelisms
+            .pop()
+            .expect("Ran out of any_parallelisms.");
+
+        // can only group into less groups than we currently have
+        debug_assert!(parallelism > 0);
+        debug_assert!(parallelism <= self.set_groups.len());
+
+        // split them into even groups
+        let num_sets = self.set_groups[0].len();
+        let mut new_set_groups = Vec::with_capacity(parallelism);
+        let base_size = self.set_groups.len() / parallelism;
+        let remainder = self.set_groups.len() % parallelism;
+        let mut start_idx = 0;
+        for group_idx in 0..parallelism {
+            let extra = if group_idx < remainder { 1 } else { 0 };
+            let end_idx = start_idx + base_size + extra;
+
+            let mut set_group = Vec::with_capacity(num_sets);
+            for set_idx in 0..num_sets {
+                let mut curr_set: Option<CompositionSet> = None;
+                for i in start_idx..end_idx {
+                    if let Some(set) = &mut curr_set {
+                        if let Some(next_set) = self.set_groups[i][set_idx].take() {
+                            set.combine(next_set).unwrap();
+                        }
+                    } else {
+                        curr_set = self.set_groups[i][set_idx].take();
+                    }
+                }
+                set_group.push(curr_set);
+            }
+            new_set_groups.push(set_group);
+            start_idx = end_idx;
+        }
+        self.set_groups = new_set_groups;
+
+        if let Some(left) = self.left.as_mut() {
+            left.reduce_any_parallelism(any_parallelisms);
+        } else {
+            debug_assert!(any_parallelisms.len() == 0);
+        }
+    }
+
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
         debug_assert!(self.set_groups_idx < self.set_groups.len());
         for (i, write_idx) in self.write_idcs.iter().enumerate() {
-            // TODO: taking (i.e. moving) should be ok here but check if that is actually correct
-            to_fill[*write_idx] = self.set_groups[self.set_groups_idx][i].take();
+            to_fill[*write_idx] = self.set_groups[self.set_groups_idx][i].clone();
         }
         if let Some(left) = &mut self.left {
             left.fill_in(to_fill);
@@ -542,8 +647,8 @@ impl JoinIterator for AnyIterator {
     }
 
     fn advance(&mut self) -> bool {
-        if self.set_groups_idx + 1 < self.set_groups.len() {
-            self.set_groups_idx += 1;
+        self.set_groups_idx += 1;
+        if self.set_groups_idx < self.set_groups.len() {
             true
         } else {
             if let Some(left) = &mut self.left {
@@ -559,9 +664,5 @@ impl JoinIterator for AnyIterator {
                 false
             }
         }
-    }
-
-    fn get_key(&self) -> u32 {
-        panic!("get_key should not be called on AnyIterator.");
     }
 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -411,11 +411,130 @@ impl JoinIterator for SetKeyIterator {
 }
 
 /// Implements the JoinIterator for the `any` shardings.
-/// TODO
 struct AnyIterator {
     left: Option<Box<dyn JoinIterator>>,
-    set: CompositionSet,
-    set_idx: usize,
-    key: u32,
-    write_index: usize,
+    set_groups: Vec<Vec<Option<CompositionSet>>>,
+    set_groups_idx: usize,
+    write_idcs: Vec<usize>,
+}
+
+impl AnyIterator {
+    fn new(
+        left: Option<Box<dyn JoinIterator>>,
+        sets: Vec<CompositionSet>,
+        strategies: Vec<JoinStrategy>,
+        write_idcs: Vec<usize>,
+        num_groups: usize,
+        sharding: ShardingMode,
+    ) -> Option<Box<dyn JoinIterator>> {
+        debug_assert!(num_groups > 1); // for one group directly use a SetAllIterator
+        let num_sets = sets.len();
+
+        // build the iterators to generate all sets so we can then group them
+        let mut inner_join_it = None;
+        for (i, set) in sets.into_iter().enumerate() {
+            if sharding == ShardingMode::AnyEach {
+                inner_join_it = SetEachIterator::new(inner_join_it, set, i);
+            } else {
+                debug_assert!(sharding == ShardingMode::AnyKey);
+                let strategy = if i > 0 {
+                    strategies[i - 1]
+                } else {
+                    JoinStrategy::Cross
+                };
+                inner_join_it = SetKeyIterator::new(inner_join_it, set, strategy, i);
+            }
+        }
+
+        if let Some(mut it) = inner_join_it {
+            let mut inner_sharding = Vec::new();
+
+            // generate all sets
+            let mut first_sets = Vec::with_capacity(num_sets);
+            first_sets.resize(num_sets, None);
+            it.fill_in(&mut first_sets);
+            inner_sharding.push(first_sets);
+            while it.advance() {
+                let mut next_sets = Vec::with_capacity(num_sets);
+                next_sets.resize(num_sets, None);
+                it.fill_in(&mut next_sets);
+                inner_sharding.push(next_sets);
+            }
+
+            // split them into even groups
+            let mut set_groups = Vec::with_capacity(num_groups);
+            let base_size = inner_sharding.len() / num_groups;
+            let remainder = inner_sharding.len() % num_groups;
+            let mut start_idx = 0;
+            for group_idx in 0..num_groups {
+                let extra = if group_idx < remainder { 1 } else { 0 };
+                let end_idx = start_idx + base_size + extra;
+
+                let mut set_group = Vec::with_capacity(num_sets);
+                for set_idx in 0..num_sets {
+                    let mut curr_set: Option<CompositionSet> = None;
+                    for i in start_idx..end_idx {
+                        if let Some(set) = &mut curr_set {
+                            if let Some(next_set) = inner_sharding[i][set_idx].take() {
+                                set.combine(next_set).unwrap();
+                            }
+                        } else {
+                            curr_set = inner_sharding[i][set_idx].take();
+                        }
+                    }
+                    set_group.push(curr_set);
+                }
+                set_groups.push(set_group);
+                start_idx = end_idx;
+            }
+
+            Some(Box::new(Self {
+                left,
+                set_groups,
+                set_groups_idx: 0,
+                write_idcs,
+            }))
+        } else {
+            // we failed to build the inner join iterators...
+            None
+        }
+    }
+}
+
+impl JoinIterator for AnyIterator {
+    fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
+        if self.set_groups_idx < self.set_groups.len() {
+            for (i, write_idx) in self.write_idcs.iter().enumerate() {
+                // TODO: taking (i.e. moving) should be ok here but check if that is actually correct
+                to_fill[*write_idx] = self.set_groups[self.set_groups_idx][i].take();
+            }
+        }
+        if let Some(left) = &mut self.left {
+            left.fill_in(to_fill);
+        }
+    }
+
+    fn advance(&mut self) -> bool {
+        if self.set_groups_idx + 1 < self.set_groups.len() {
+            self.set_groups_idx += 1;
+            true
+        } else {
+            if let Some(left) = &mut self.left {
+                if left.advance() {
+                    self.set_groups_idx = 0;
+                    true
+                } else {
+                    // set sets_idx to len so we can't accidentally copy something
+                    self.set_groups_idx = self.set_groups.len();
+                    false
+                }
+            } else {
+                false
+            }
+        }
+    }
+
+    fn get_key(&self) -> u32 {
+        panic!("get_key should not be called on AnyIterator.");
+    }
 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -1,0 +1,421 @@
+use crate::composition::{CompositionSet, JoinStrategy, ShardingMode};
+
+trait JoinIterator {
+    fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>);
+    fn advance(&mut self) -> bool;
+    fn get_key(&self) -> u32;
+}
+
+/// Implements the JoinIterator for the `all` sharding.
+struct SetAllIterator {
+    left: Option<Box<dyn JoinIterator>>,
+    set: CompositionSet,
+    write_idx: usize,
+}
+
+impl SetAllIterator {
+    fn new(
+        left: Option<Box<dyn JoinIterator>>,
+        set: CompositionSet,
+        write_idx: usize,
+    ) -> Option<Box<dyn JoinIterator>> {
+        if set.is_empty() {
+            return left;
+        }
+
+        Some(Box::new(Self {
+            left,
+            set,
+            write_idx,
+        }))
+    }
+}
+
+impl JoinIterator for SetAllIterator {
+    fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
+        to_fill[self.write_idx] = Some(self.set.clone());
+        if let Some(left) = &mut self.left {
+            left.fill_in(to_fill);
+        }
+    }
+
+    fn advance(&mut self) -> bool {
+        if let Some(left) = &mut self.left {
+            left.advance()
+        } else {
+            false
+        }
+    }
+
+    fn get_key(&self) -> u32 {
+        panic!("get_key should not be called on SetAllIterator.");
+    }
+}
+
+/// Implements the JoinIterator for the `each` sharding.
+struct SetEachIterator {
+    left: Option<Box<dyn JoinIterator>>,
+    sets: Vec<CompositionSet>,
+    sets_idx: usize,
+    write_idx: usize,
+}
+
+impl SetEachIterator {
+    fn new(
+        left: Option<Box<dyn JoinIterator>>,
+        set: CompositionSet,
+        write_idx: usize,
+    ) -> Option<Box<dyn JoinIterator>> {
+        let sets = set.shard(ShardingMode::Each);
+        if sets.is_empty() {
+            return left;
+        }
+
+        Some(Box::new(Self {
+            left,
+            sets,
+            sets_idx: 0,
+            write_idx,
+        }))
+    }
+}
+
+impl JoinIterator for SetEachIterator {
+    fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
+        if self.sets_idx < self.sets.len() {
+            to_fill[self.write_idx] = Some(self.sets[self.sets_idx].clone());
+        }
+        if let Some(left) = &mut self.left {
+            left.fill_in(to_fill);
+        }
+    }
+
+    fn advance(&mut self) -> bool {
+        if self.sets_idx + 1 < self.sets.len() {
+            self.sets_idx += 1;
+            true
+        } else {
+            if let Some(left) = &mut self.left {
+                if left.advance() {
+                    self.sets_idx = 0;
+                    true
+                } else {
+                    // set sets_idx to len so we can't accidentally copy something
+                    self.sets_idx = self.sets.len();
+                    false
+                }
+            } else {
+                false
+            }
+        }
+    }
+
+    fn get_key(&self) -> u32 {
+        panic!("get_key should not be called on SetEachIterator.");
+    }
+}
+
+/// Implements the JoinIterator for the `keyed` sharding.
+struct SetKeyIterator {
+    left: Option<Box<dyn JoinIterator>>,
+    sets: Vec<CompositionSet>,
+    sets_idx: usize,
+    key: u32,
+    strategy: JoinStrategy,
+    write_idx: usize,
+}
+
+impl SetKeyIterator {
+    fn new(
+        mut left: Option<Box<dyn JoinIterator>>,
+        set: CompositionSet,
+        strategy: JoinStrategy,
+        write_idx: usize,
+    ) -> Option<Box<dyn JoinIterator>> {
+        let sets = set.shard(ShardingMode::Key);
+        if sets.is_empty() {
+            return left;
+        }
+
+        let mut sets_idx = 0;
+        let mut key = sets[0].item_list[0].0;
+        if let Some(left_it) = &mut left {
+            match strategy {
+                JoinStrategy::Inner => {
+                    while sets_idx < sets.len() && key != left_it.get_key() {
+                        if key < left_it.get_key() {
+                            sets_idx += 1;
+                            if sets_idx < sets.len() {
+                                key = sets[sets_idx].item_list[0].0;
+                            }
+                        } else {
+                            if !left_it.advance() {
+                                sets_idx = sets.len();
+                            }
+                        }
+                    }
+                    if sets_idx == sets.len() {
+                        return None;
+                    }
+                }
+                JoinStrategy::Left => {
+                    while sets_idx < sets.len() && sets[sets_idx].item_list[0].0 < left_it.get_key()
+                    {
+                        sets_idx += 1;
+                    }
+                    key = left_it.get_key();
+                    if sets_idx == sets.len() {
+                        return left;
+                    }
+                }
+                JoinStrategy::Outer => {
+                    if left_it.get_key() < key {
+                        key = left_it.get_key();
+                    }
+                    // else already has the correct key set
+                }
+                JoinStrategy::Right | JoinStrategy::Cross => (),
+            }
+        } else {
+            match strategy {
+                JoinStrategy::Inner | JoinStrategy::Left => {
+                    return None;
+                }
+                _ => (),
+            }
+        }
+
+        Some(Box::new(Self {
+            left,
+            sets,
+            sets_idx,
+            key,
+            strategy,
+            write_idx,
+        }))
+    }
+}
+
+impl JoinIterator for SetKeyIterator {
+    fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
+        let has_filled =
+            self.sets_idx < self.sets.len() && self.key == self.sets[self.sets_idx].item_list[0].0;
+        if has_filled {
+            to_fill[self.write_idx] = Some(self.sets[self.sets_idx].clone());
+        }
+        if let Some(left) = &mut self.left {
+            match self.strategy {
+                // modes for which always want left to fill in
+                JoinStrategy::Cross | JoinStrategy::Left => left.fill_in(to_fill),
+                // Only want to fill left if it is the one with the current key
+                JoinStrategy::Outer => {
+                    if self.key == left.get_key() {
+                        left.fill_in(to_fill)
+                    }
+                }
+                // Only want left to fill if this iterator has filled something in
+                JoinStrategy::Inner => {
+                    if has_filled {
+                        left.fill_in(to_fill)
+                    }
+                }
+                // Only want left to fill if this iterator has filled and the keys match
+                JoinStrategy::Right => {
+                    if has_filled && self.key == left.get_key() {
+                        left.fill_in(to_fill)
+                    }
+                }
+            }
+        };
+    }
+
+    fn advance(&mut self) -> bool {
+        if self.sets_idx == self.sets.len() {
+            return false;
+        }
+
+        if let Some(left) = &mut self.left {
+            match self.strategy {
+                JoinStrategy::Inner => {
+                    // advance both at least once for inner
+                    // left is advanced on checking (after checking right can stil be advanced)
+                    // right is advanced after
+                    if self.sets_idx + 1 >= self.sets.len() || !left.advance() {
+                        self.sets_idx = self.sets.len();
+                        return false;
+                    }
+                    self.sets_idx += 1;
+                    self.key = self.sets[self.sets_idx].item_list[0].0;
+                    while self.key != left.get_key() {
+                        if self.key > left.get_key() {
+                            if !left.advance() {
+                                self.sets_idx = self.sets.len();
+                                return false;
+                            }
+                        // need to advance right and are able to do so
+                        } else if self.key < left.get_key() {
+                            if self.sets_idx + 1 >= self.sets.len() {
+                                self.sets_idx = self.sets.len();
+                                return false;
+                            } else {
+                                self.sets_idx += 1;
+                                self.key = self.sets[self.sets_idx].item_list[0].0;
+                            }
+                        }
+                    }
+                    true
+                }
+                JoinStrategy::Left => {
+                    // advance left and see if we can match
+                    if left.advance() {
+                        while self.sets_idx + 1 < self.sets.len()
+                            && self.sets[self.sets_idx].item_list[0].0 < left.get_key()
+                        {
+                            self.sets_idx += 1;
+                        }
+                        // after this the key is guaranteed to be equal to the left key or bigger
+                        // so if the keys match that will be fine for copy in, otherwise this will be skipped
+                        // if the key already equal or bigger, it was not advanced
+                        self.key = left.get_key();
+                        true
+                    } else {
+                        self.sets_idx = self.sets.len();
+                        false
+                    }
+                }
+                JoinStrategy::Right => {
+                    if self.sets_idx + 1 >= self.sets.len() {
+                        self.sets_idx = self.sets.len();
+                        return false;
+                    }
+                    self.sets_idx += 1;
+                    self.key = self.sets[self.sets_idx].item_list[0].0;
+                    while self.key > left.get_key() {
+                        if !left.advance() {
+                            break;
+                        }
+                    }
+                    true
+                }
+                JoinStrategy::Outer => {
+                    let current_self_key = self.sets[self.sets_idx].item_list[0].0;
+                    let right_can_be_advanced = self.sets_idx + 1 < self.sets.len();
+                    // check if one of the already known keys is bigger, if so we know we can adavance
+                    if self.key < left.get_key() {
+                        // last key was set from right, since left is bigger
+                        debug_assert_eq!(self.key, current_self_key);
+                        // if right can be advance it should be advanced, otherwise just set key to left one
+                        if right_can_be_advanced {
+                            self.sets_idx += 1;
+                            // new right might still be smaller than left key
+                            self.key =
+                                u32::min(self.sets[self.sets_idx].item_list[0].0, left.get_key());
+                        } else {
+                            self.key = left.get_key();
+                        }
+                        true
+                    } else if self.key < current_self_key {
+                        // the last key was set from left, since right is bigger
+                        debug_assert_eq!(self.key, left.get_key());
+                        // if left can be adnvanced it should be, if not move
+                        if left.advance() {
+                            // new left key might still be smaller than right
+                            self.key =
+                                u32::min(self.sets[self.sets_idx].item_list[0].0, left.get_key());
+                        } else {
+                            //  left did not advance, so set key to current right key
+                            self.key = current_self_key;
+                        }
+                        true
+                    } else if self.key == left.get_key() && self.key == current_self_key {
+                        // both keys are the same, so advance any that are possible to advance and take new key from there
+                        let left_advance_success = left.advance();
+                        if right_can_be_advanced {
+                            self.sets_idx += 1;
+                        }
+                        match (right_can_be_advanced, left_advance_success) {
+                            (true, true) => {
+                                self.key = u32::min(
+                                    self.sets[self.sets_idx].item_list[0].0,
+                                    left.get_key(),
+                                );
+                                true
+                            }
+                            (true, false) => {
+                                self.key = self.sets[self.sets_idx].item_list[0].0;
+                                true
+                            }
+                            (false, true) => {
+                                self.key = left.get_key();
+                                true
+                            }
+                            (false, false) => {
+                                self.sets_idx = self.sets.len();
+                                false
+                            }
+                        }
+                    } else {
+                        // the key is already set to the bigger of the two current keys, try to advance that one
+                        if current_self_key == left.get_key() {
+                            let did_advance = left.advance();
+                            self.key = left.get_key();
+                            did_advance
+                        } else {
+                            if right_can_be_advanced {
+                                self.sets_idx += 1;
+                                self.key = self.sets[self.sets_idx].item_list[0].0;
+                            }
+                            right_can_be_advanced
+                        }
+                    }
+                }
+                JoinStrategy::Cross => {
+                    if self.sets_idx + 1 < self.sets.len() {
+                        self.sets_idx += 1;
+                        self.key = self.sets[self.sets_idx].item_list[0].0;
+                        true
+                    } else if left.advance() {
+                        self.sets_idx = 0;
+                        self.key = self.sets[0].item_list[0].0;
+                        true
+                    } else {
+                        // set right index to len so we can't accidentally copy something
+                        self.sets_idx = self.sets.len();
+                        false
+                    }
+                }
+            }
+        } else {
+            if self.sets_idx + 1 >= self.sets.len() {
+                self.sets_idx = self.sets.len();
+                false
+            } else {
+                // advancing only makes sense for certain modes here
+                if self.strategy == JoinStrategy::Right
+                    || self.strategy == JoinStrategy::Outer
+                    || self.strategy == JoinStrategy::Cross
+                {
+                    self.sets_idx += 1;
+                    self.key = self.sets[self.sets_idx].item_list[0].0;
+                    true
+                } else {
+                    panic!("Should never have join iterator with left or inner that has None for the left value");
+                }
+            }
+        }
+    }
+
+    fn get_key(&self) -> u32 {
+        self.key
+    }
+}
+
+/// Implements the JoinIterator for the `any` shardings.
+/// TODO
+struct AnyIterator {
+    left: Option<Box<dyn JoinIterator>>,
+    set: CompositionSet,
+    set_idx: usize,
+    key: u32,
+    write_index: usize,
+}

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use crate::composition::{CompositionSet, JoinStrategy, ShardingMode};
 
 pub(super) trait JoinIterator {
@@ -64,8 +66,8 @@ impl JoinIterator for SetAllIterator {
 /// Implements the JoinIterator for the `each` sharding.
 pub(super) struct SetEachIterator {
     left: Option<Box<dyn JoinIterator>>,
-    sets: Vec<CompositionSet>,
-    sets_idx: usize,
+    set: CompositionSet,
+    item_idx: usize,
     write_idx: usize,
 }
 
@@ -75,15 +77,14 @@ impl SetEachIterator {
         set: CompositionSet,
         write_idx: usize,
     ) -> Option<Box<dyn JoinIterator>> {
-        let sets = set.shard(ShardingMode::Each);
-        if sets.is_empty() {
+        if set.is_empty() {
             return left;
         }
 
         Some(Box::new(Self {
             left,
-            sets,
-            sets_idx: 0,
+            set,
+            item_idx: 0,
             write_idx,
         }))
     }
@@ -91,8 +92,11 @@ impl SetEachIterator {
 
 impl JoinIterator for SetEachIterator {
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-        if self.sets_idx < self.sets.len() {
-            to_fill[self.write_idx] = Some(self.sets[self.sets_idx].clone());
+        if self.item_idx < self.set.item_list.len() {
+            to_fill[self.write_idx] = Some(CompositionSet {
+                item_list: vec![self.set.item_list[self.item_idx].clone()],
+                set_index: self.set.set_index,
+            });
         }
         if let Some(left) = &mut self.left {
             left.fill_in(to_fill);
@@ -100,17 +104,17 @@ impl JoinIterator for SetEachIterator {
     }
 
     fn advance(&mut self) -> bool {
-        if self.sets_idx + 1 < self.sets.len() {
-            self.sets_idx += 1;
+        if self.item_idx + 1 < self.set.item_list.len() {
+            self.item_idx += 1;
             true
         } else {
             if let Some(left) = &mut self.left {
                 if left.advance() {
-                    self.sets_idx = 0;
+                    self.item_idx = 0;
                     true
                 } else {
                     // set sets_idx to len so we can't accidentally copy something
-                    self.sets_idx = self.sets.len();
+                    self.item_idx = self.set.item_list.len();
                     false
                 }
             } else {
@@ -127,8 +131,9 @@ impl JoinIterator for SetEachIterator {
 /// Implements the JoinIterator for the `keyed` sharding.
 pub(super) struct SetKeyIterator {
     left: Option<Box<dyn JoinIterator>>,
-    sets: Vec<CompositionSet>,
-    sets_idx: usize,
+    set: CompositionSet,
+    key_groups: Vec<(u32, Range<usize>)>,
+    key_groups_idx: usize,
     key: u32,
     strategy: JoinStrategy,
     write_idx: usize,
@@ -141,39 +146,47 @@ impl SetKeyIterator {
         strategy: JoinStrategy,
         write_idx: usize,
     ) -> Option<Box<dyn JoinIterator>> {
-        let sets = set.shard(ShardingMode::Key);
-        if sets.is_empty() {
+        let mut key_groups = Vec::new();
+        let mut start_idx = 0;
+        for chunk in set.item_list.chunk_by(|a, b| a.0 == b.0) {
+            let key = chunk[0].0;
+            let end_idx = start_idx + chunk.len();
+            key_groups.push((key, start_idx..end_idx));
+            start_idx = end_idx;
+        }
+        if key_groups.is_empty() {
             return left;
         }
 
-        let mut sets_idx = 0;
-        let mut key = sets[0].item_list[0].0;
+        let mut key_groups_idx = 0;
+        let mut key = key_groups[0].0;
         if let Some(left_it) = &mut left {
             match strategy {
                 JoinStrategy::Inner => {
-                    while sets_idx < sets.len() && key != left_it.get_key() {
+                    while key_groups_idx < key_groups.len() && key != left_it.get_key() {
                         if key < left_it.get_key() {
-                            sets_idx += 1;
-                            if sets_idx < sets.len() {
-                                key = sets[sets_idx].item_list[0].0;
+                            key_groups_idx += 1;
+                            if key_groups_idx < key_groups.len() {
+                                key = key_groups[key_groups_idx].0;
                             }
                         } else {
                             if !left_it.advance() {
-                                sets_idx = sets.len();
+                                key_groups_idx = key_groups.len();
                             }
                         }
                     }
-                    if sets_idx == sets.len() {
+                    if key_groups_idx == key_groups.len() {
                         return None;
                     }
                 }
                 JoinStrategy::Left => {
-                    while sets_idx < sets.len() && sets[sets_idx].item_list[0].0 < left_it.get_key()
+                    while key_groups_idx < key_groups.len()
+                        && key_groups[key_groups_idx].0 < left_it.get_key()
                     {
-                        sets_idx += 1;
+                        key_groups_idx += 1;
                     }
                     key = left_it.get_key();
-                    if sets_idx == sets.len() {
+                    if key_groups_idx == key_groups.len() {
                         return left;
                     }
                 }
@@ -196,8 +209,9 @@ impl SetKeyIterator {
 
         Some(Box::new(Self {
             left,
-            sets,
-            sets_idx,
+            set,
+            key_groups,
+            key_groups_idx,
             key,
             strategy,
             write_idx,
@@ -207,10 +221,14 @@ impl SetKeyIterator {
 
 impl JoinIterator for SetKeyIterator {
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-        let has_filled =
-            self.sets_idx < self.sets.len() && self.key == self.sets[self.sets_idx].item_list[0].0;
+        let has_filled = self.key_groups_idx < self.key_groups.len()
+            && self.key == self.key_groups[self.key_groups_idx].0;
         if has_filled {
-            to_fill[self.write_idx] = Some(self.sets[self.sets_idx].clone());
+            to_fill[self.write_idx] = Some(CompositionSet {
+                item_list: self.set.item_list[self.key_groups[self.key_groups_idx].1.clone()]
+                    .to_vec(),
+                set_index: self.set.set_index,
+            });
         }
         if let Some(left) = &mut self.left {
             match self.strategy {
@@ -239,7 +257,7 @@ impl JoinIterator for SetKeyIterator {
     }
 
     fn advance(&mut self) -> bool {
-        if self.sets_idx == self.sets.len() {
+        if self.key_groups_idx == self.key_groups.len() {
             return false;
         }
 
@@ -249,26 +267,26 @@ impl JoinIterator for SetKeyIterator {
                     // advance both at least once for inner
                     // left is advanced on checking (after checking right can stil be advanced)
                     // right is advanced after
-                    if self.sets_idx + 1 >= self.sets.len() || !left.advance() {
-                        self.sets_idx = self.sets.len();
+                    if self.key_groups_idx + 1 >= self.key_groups.len() || !left.advance() {
+                        self.key_groups_idx = self.key_groups.len();
                         return false;
                     }
-                    self.sets_idx += 1;
-                    self.key = self.sets[self.sets_idx].item_list[0].0;
+                    self.key_groups_idx += 1;
+                    self.key = self.key_groups[self.key_groups_idx].0;
                     while self.key != left.get_key() {
                         if self.key > left.get_key() {
                             if !left.advance() {
-                                self.sets_idx = self.sets.len();
+                                self.key_groups_idx = self.key_groups.len();
                                 return false;
                             }
                         // need to advance right and are able to do so
                         } else if self.key < left.get_key() {
-                            if self.sets_idx + 1 >= self.sets.len() {
-                                self.sets_idx = self.sets.len();
+                            if self.key_groups_idx + 1 >= self.key_groups.len() {
+                                self.key_groups_idx = self.key_groups.len();
                                 return false;
                             } else {
-                                self.sets_idx += 1;
-                                self.key = self.sets[self.sets_idx].item_list[0].0;
+                                self.key_groups_idx += 1;
+                                self.key = self.key_groups[self.key_groups_idx].0;
                             }
                         }
                     }
@@ -277,10 +295,10 @@ impl JoinIterator for SetKeyIterator {
                 JoinStrategy::Left => {
                     // advance left and see if we can match
                     if left.advance() {
-                        while self.sets_idx + 1 < self.sets.len()
-                            && self.sets[self.sets_idx].item_list[0].0 < left.get_key()
+                        while self.key_groups_idx + 1 < self.key_groups.len()
+                            && self.key_groups[self.key_groups_idx].0 < left.get_key()
                         {
-                            self.sets_idx += 1;
+                            self.key_groups_idx += 1;
                         }
                         // after this the key is guaranteed to be equal to the left key or bigger
                         // so if the keys match that will be fine for copy in, otherwise this will be skipped
@@ -288,17 +306,17 @@ impl JoinIterator for SetKeyIterator {
                         self.key = left.get_key();
                         true
                     } else {
-                        self.sets_idx = self.sets.len();
+                        self.key_groups_idx = self.key_groups.len();
                         false
                     }
                 }
                 JoinStrategy::Right => {
-                    if self.sets_idx + 1 >= self.sets.len() {
-                        self.sets_idx = self.sets.len();
+                    if self.key_groups_idx + 1 >= self.key_groups.len() {
+                        self.key_groups_idx = self.key_groups.len();
                         return false;
                     }
-                    self.sets_idx += 1;
-                    self.key = self.sets[self.sets_idx].item_list[0].0;
+                    self.key_groups_idx += 1;
+                    self.key = self.key_groups[self.key_groups_idx].0;
                     while self.key > left.get_key() {
                         if !left.advance() {
                             break;
@@ -307,18 +325,18 @@ impl JoinIterator for SetKeyIterator {
                     true
                 }
                 JoinStrategy::Outer => {
-                    let current_self_key = self.sets[self.sets_idx].item_list[0].0;
-                    let right_can_be_advanced = self.sets_idx + 1 < self.sets.len();
+                    let current_self_key = self.key_groups[self.key_groups_idx].0;
+                    let right_can_be_advanced = self.key_groups_idx + 1 < self.key_groups.len();
                     // check if one of the already known keys is bigger, if so we know we can adavance
                     if self.key < left.get_key() {
                         // last key was set from right, since left is bigger
                         debug_assert_eq!(self.key, current_self_key);
                         // if right can be advance it should be advanced, otherwise just set key to left one
                         if right_can_be_advanced {
-                            self.sets_idx += 1;
+                            self.key_groups_idx += 1;
                             // new right might still be smaller than left key
                             self.key =
-                                u32::min(self.sets[self.sets_idx].item_list[0].0, left.get_key());
+                                u32::min(self.key_groups[self.key_groups_idx].0, left.get_key());
                         } else {
                             self.key = left.get_key();
                         }
@@ -330,7 +348,7 @@ impl JoinIterator for SetKeyIterator {
                         if left.advance() {
                             // new left key might still be smaller than right
                             self.key =
-                                u32::min(self.sets[self.sets_idx].item_list[0].0, left.get_key());
+                                u32::min(self.key_groups[self.key_groups_idx].0, left.get_key());
                         } else {
                             // left did not advance, so set key to current right key
                             self.key = current_self_key;
@@ -340,18 +358,18 @@ impl JoinIterator for SetKeyIterator {
                         // both keys are the same, so advance any that are possible to advance and take new key from there
                         let left_advance_success = left.advance();
                         if right_can_be_advanced {
-                            self.sets_idx += 1;
+                            self.key_groups_idx += 1;
                         }
                         match (right_can_be_advanced, left_advance_success) {
                             (true, true) => {
                                 self.key = u32::min(
-                                    self.sets[self.sets_idx].item_list[0].0,
+                                    self.key_groups[self.key_groups_idx].0,
                                     left.get_key(),
                                 );
                                 true
                             }
                             (true, false) => {
-                                self.key = self.sets[self.sets_idx].item_list[0].0;
+                                self.key = self.key_groups[self.key_groups_idx].0;
                                 true
                             }
                             (false, true) => {
@@ -359,7 +377,7 @@ impl JoinIterator for SetKeyIterator {
                                 true
                             }
                             (false, false) => {
-                                self.sets_idx = self.sets.len();
+                                self.key_groups_idx = self.key_groups.len();
                                 false
                             }
                         }
@@ -371,32 +389,32 @@ impl JoinIterator for SetKeyIterator {
                             did_advance
                         } else {
                             if right_can_be_advanced {
-                                self.sets_idx += 1;
-                                self.key = self.sets[self.sets_idx].item_list[0].0;
+                                self.key_groups_idx += 1;
+                                self.key = self.key_groups[self.key_groups_idx].0;
                             }
                             right_can_be_advanced
                         }
                     }
                 }
                 JoinStrategy::Cross => {
-                    if self.sets_idx + 1 < self.sets.len() {
-                        self.sets_idx += 1;
-                        self.key = self.sets[self.sets_idx].item_list[0].0;
+                    if self.key_groups_idx + 1 < self.key_groups.len() {
+                        self.key_groups_idx += 1;
+                        self.key = self.key_groups[self.key_groups_idx].0;
                         true
                     } else if left.advance() {
-                        self.sets_idx = 0;
-                        self.key = self.sets[0].item_list[0].0;
+                        self.key_groups_idx = 0;
+                        self.key = self.key_groups[0].0;
                         true
                     } else {
                         // set right index to len so we can't accidentally copy something
-                        self.sets_idx = self.sets.len();
+                        self.key_groups_idx = self.key_groups.len();
                         false
                     }
                 }
             }
         } else {
-            if self.sets_idx + 1 >= self.sets.len() {
-                self.sets_idx = self.sets.len();
+            if self.key_groups_idx + 1 >= self.key_groups.len() {
+                self.key_groups_idx = self.key_groups.len();
                 false
             } else {
                 // advancing only makes sense for certain modes here
@@ -404,8 +422,8 @@ impl JoinIterator for SetKeyIterator {
                     || self.strategy == JoinStrategy::Outer
                     || self.strategy == JoinStrategy::Cross
                 {
-                    self.sets_idx += 1;
-                    self.key = self.sets[self.sets_idx].item_list[0].0;
+                    self.key_groups_idx += 1;
+                    self.key = self.key_groups[self.key_groups_idx].0;
                     true
                 } else {
                     panic!("Should never have join iterator with left or inner that has None for the left value");
@@ -534,7 +552,7 @@ impl JoinIterator for AnyIterator {
                     self.set_groups_idx = 0;
                     true
                 } else {
-                    // set sets_idx to len so we can't accidentally copy something
+                    // set key_groups_idx to len so we can't accidentally copy something
                     self.set_groups_idx = self.set_groups.len();
                     false
                 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -92,12 +92,11 @@ impl SetEachIterator {
 
 impl JoinIterator for SetEachIterator {
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-        if self.item_idx < self.set.item_list.len() {
-            to_fill[self.write_idx] = Some(CompositionSet {
-                item_list: vec![self.set.item_list[self.item_idx].clone()],
-                set_index: self.set.set_index,
-            });
-        }
+        debug_assert!(self.item_idx < self.set.item_list.len());
+        to_fill[self.write_idx] = Some(CompositionSet {
+            item_list: vec![self.set.item_list[self.item_idx].clone()],
+            set_index: self.set.set_index,
+        });
         if let Some(left) = &mut self.left {
             left.fill_in(to_fill);
         }
@@ -221,15 +220,12 @@ impl SetKeyIterator {
 
 impl JoinIterator for SetKeyIterator {
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-        let has_filled = self.key_groups_idx < self.key_groups.len()
-            && self.key == self.key_groups[self.key_groups_idx].0;
-        if has_filled {
-            to_fill[self.write_idx] = Some(CompositionSet {
-                item_list: self.set.item_list[self.key_groups[self.key_groups_idx].1.clone()]
-                    .to_vec(),
-                set_index: self.set.set_index,
-            });
-        }
+        debug_assert!(self.key_groups_idx < self.key_groups.len());
+        debug_assert!(self.key == self.key_groups[self.key_groups_idx].0);
+        to_fill[self.write_idx] = Some(CompositionSet {
+            item_list: self.set.item_list[self.key_groups[self.key_groups_idx].1.clone()].to_vec(),
+            set_index: self.set.set_index,
+        });
         if let Some(left) = &mut self.left {
             match self.strategy {
                 // modes for which always want left to fill in
@@ -241,14 +237,10 @@ impl JoinIterator for SetKeyIterator {
                     }
                 }
                 // Only want left to fill if this iterator has filled something in
-                JoinStrategy::Inner => {
-                    if has_filled {
-                        left.fill_in(to_fill)
-                    }
-                }
+                JoinStrategy::Inner => left.fill_in(to_fill),
                 // Only want left to fill if this iterator has filled and the keys match
                 JoinStrategy::Right => {
-                    if has_filled && self.key == left.get_key() {
+                    if self.key == left.get_key() {
                         left.fill_in(to_fill)
                     }
                 }
@@ -257,7 +249,7 @@ impl JoinIterator for SetKeyIterator {
     }
 
     fn advance(&mut self) -> bool {
-        if self.key_groups_idx == self.key_groups.len() {
+        if self.key_groups_idx >= self.key_groups.len() {
             return false;
         }
 
@@ -267,11 +259,11 @@ impl JoinIterator for SetKeyIterator {
                     // advance both at least once for inner
                     // left is advanced on checking (after checking right can stil be advanced)
                     // right is advanced after
-                    if self.key_groups_idx + 1 >= self.key_groups.len() || !left.advance() {
+                    self.key_groups_idx += 1;
+                    if self.key_groups_idx >= self.key_groups.len() || !left.advance() {
                         self.key_groups_idx = self.key_groups.len();
                         return false;
                     }
-                    self.key_groups_idx += 1;
                     self.key = self.key_groups[self.key_groups_idx].0;
                     while self.key != left.get_key() {
                         if self.key > left.get_key() {
@@ -281,11 +273,11 @@ impl JoinIterator for SetKeyIterator {
                             }
                         // need to advance right and are able to do so
                         } else if self.key < left.get_key() {
-                            if self.key_groups_idx + 1 >= self.key_groups.len() {
+                            self.key_groups_idx += 1;
+                            if self.key_groups_idx >= self.key_groups.len() {
                                 self.key_groups_idx = self.key_groups.len();
                                 return false;
                             } else {
-                                self.key_groups_idx += 1;
                                 self.key = self.key_groups[self.key_groups_idx].0;
                             }
                         }
@@ -344,7 +336,7 @@ impl JoinIterator for SetKeyIterator {
                     } else if self.key < current_self_key {
                         // the last key was set from left, since right is bigger
                         debug_assert_eq!(self.key, left.get_key());
-                        // if left can be adnvanced it should be, if not move
+                        // if left can be advanced it should be, if not move
                         if left.advance() {
                             // new left key might still be smaller than right
                             self.key =
@@ -352,6 +344,7 @@ impl JoinIterator for SetKeyIterator {
                         } else {
                             // left did not advance, so set key to current right key
                             self.key = current_self_key;
+                            self.left = None; // asserts that left.advance() is not called again
                         }
                         true
                     } else if self.key == left.get_key() && self.key == current_self_key {
@@ -531,11 +524,10 @@ impl AnyIterator {
 
 impl JoinIterator for AnyIterator {
     fn fill_in(&mut self, to_fill: &mut Vec<Option<CompositionSet>>) {
-        if self.set_groups_idx < self.set_groups.len() {
-            for (i, write_idx) in self.write_idcs.iter().enumerate() {
-                // TODO: taking (i.e. moving) should be ok here but check if that is actually correct
-                to_fill[*write_idx] = self.set_groups[self.set_groups_idx][i].take();
-            }
+        debug_assert!(self.set_groups_idx < self.set_groups.len());
+        for (i, write_idx) in self.write_idcs.iter().enumerate() {
+            // TODO: taking (i.e. moving) should be ok here but check if that is actually correct
+            to_fill[*write_idx] = self.set_groups[self.set_groups_idx][i].take();
         }
         if let Some(left) = &mut self.left {
             left.fill_in(to_fill);

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -543,7 +543,7 @@ impl AnyIterator {
         strategies: Vec<JoinStrategy>,
         write_idcs: Vec<usize>,
         sharding: ShardingMode,
-    ) -> (Option<Box<AnyIterator>>, usize) {
+    ) -> (Option<Box<dyn JoinIterator>>, usize) {
         let num_sets = sets.len();
         debug_assert!(num_sets > 0);
 
@@ -594,8 +594,8 @@ impl AnyIterator {
                 max_parallelism,
             )
         } else {
-            // we failed to build the inner join iterators...
-            (None, 0)
+            // no inner join iterator was built -> this iterator will no produce any sets
+            (left, 0)
         }
     }
 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -200,7 +200,7 @@ fn key_set_union(curr_keys: &mut Vec<u32>, new_key_groups: &Vec<(u32, Range<usiz
 
     // push remaining elements from whichever vec isn't empty
     result.extend_from_slice(&curr_keys[i..]);
-    result.extend(new_key_groups.iter().skip(j).map(|(k, _)| k));
+    result.extend(new_key_groups[j..].iter().map(|(k, _)| k));
 
     *curr_keys = result;
 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -6,7 +6,7 @@ pub(super) trait JoinIterator {
     /// Reduces the parallelism of all `AnyIterators` in the iterator chain by combining some sets.
     /// We expect this function is only called once, otherwise, we could end up with unevenly
     /// distributed or completely messed up groups.
-    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>);
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize, bool)>);
 
     /// Fills the given composition set vector with the current iterator state.
     /// This is undefined behaviour if the previous `advance` call returned `false`.
@@ -44,7 +44,7 @@ impl SetAllIterator {
 }
 
 impl JoinIterator for SetAllIterator {
-    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>) {
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize, bool)>) {
         if let Some(left) = self.left.as_mut() {
             left.reduce_any_parallelism(any_parallelisms);
         } else {
@@ -98,7 +98,7 @@ impl SetEachIterator {
 }
 
 impl JoinIterator for SetEachIterator {
-    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>) {
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize, bool)>) {
         if let Some(left) = self.left.as_mut() {
             left.reduce_any_parallelism(any_parallelisms);
         } else {
@@ -302,7 +302,7 @@ impl SetKeyIterator {
 }
 
 impl JoinIterator for SetKeyIterator {
-    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize)>) {
+    fn reduce_any_parallelism(&mut self, any_parallelisms: Vec<(usize, usize, bool)>) {
         debug_assert!(any_parallelisms.len() == 0);
     }
 
@@ -601,8 +601,8 @@ impl AnyIterator {
 }
 
 impl JoinIterator for AnyIterator {
-    fn reduce_any_parallelism(&mut self, mut any_parallelisms: Vec<(usize, usize)>) {
-        let (_, parallelism) = any_parallelisms
+    fn reduce_any_parallelism(&mut self, mut any_parallelisms: Vec<(usize, usize, bool)>) {
+        let (_, parallelism, _) = any_parallelisms
             .pop()
             .expect("Ran out of any_parallelisms.");
 


### PR DESCRIPTION
Added two new shardings, `anyKeyed` and `anyEach`, which allow the runtime to control the parallelism by grouping items that would otherwise lead to multiple invocations into one.

_More detailed changes:_
- moved join iterators to separate file (`composition/join_iterator.rs`) and changed `JoinIterator` to be a trait which is implemented by four specialized iterators for `all`, `each`, `key`, and `any` shardings
- inlined the sharding computation and parallelism computation into iterator creation process allowing to decide the parallelism of the `any`-sharded sets while creating the iterators
- updated parser and function registry to reorder the set such that keyed sets are iterated over first