### PR TITLE
Change CompositionSet to contain items directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
 dependencies = [
  "anstyle",
  "bstr",
@@ -239,9 +239,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1166,7 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1176,16 +1176,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -1239,9 +1229,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1284,9 +1274,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1366,7 +1356,7 @@ dependencies = [
  "enum_dispatch",
  "openssl",
  "r2d2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "url",
 ]
 
@@ -1504,15 +1494,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1545,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1765,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -1813,9 +1802,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1999,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2012,18 +2001,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2266,15 +2255,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2398,9 +2387,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
+checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
 dependencies = [
  "env_logger 0.11.10",
  "test-log-macros",
@@ -2408,14 +2397,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-log-macros"
-version = "0.2.19"
+name = "test-log-core"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn",
+ "test-log-core",
 ]
 
 [[package]]
@@ -2486,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2562,20 +2561,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2768,11 +2767,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2781,14 +2780,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2799,9 +2798,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2809,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2819,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2832,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -2875,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2954,15 +2953,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -3048,6 +3038,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/dispatcher/src/dispatcher.rs
+++ b/dispatcher/src/dispatcher.rs
@@ -237,10 +237,8 @@ impl Dispatcher {
                     }) = in_set_decriptor
                     {
                         if let Some(comp_set) = inputs.get(*composition_id) {
-                            // this means the a non optional set is empty, so we can skip it and directly queue all outputs are ready none
-                            if !*optional
-                                && (comp_set.is_none() || comp_set.as_ref().unwrap().is_empty())
-                            {
+                            // this means the a non optional set None, so we can skip it and directly queue all outputs are ready None
+                            if !*optional && comp_set.is_none() {
                                 let new_sets = deps
                                     .output_set_ids
                                     .iter()
@@ -252,6 +250,11 @@ impl Dispatcher {
                                 return None;
                             }
                             if let Some(set) = comp_set {
+                                debug_assert_ne!(
+                                    0,
+                                    set.len(),
+                                    "Expect sets that are some to have at least one item"
+                                );
                                 ready_inputs[function_index] = Some((*sharding, set.clone()));
                             }
                         } else {
@@ -311,10 +314,7 @@ impl Dispatcher {
                             )
                             .map(|((comp_index, function_index), (mode, optional))| {
                                 // if it was not optional skip executing and push all output sets
-                                if !optional
-                                    && (composition_set_option.is_none()
-                                        || composition_set_option.as_ref().unwrap().is_empty())
-                                {
+                                if !optional && composition_set_option.is_none() {
                                     let new_sets = args
                                         .output_mapping
                                         .iter()
@@ -326,9 +326,15 @@ impl Dispatcher {
                                         .push(Either::Left(ready(Ok((new_sets, Vec::new())))));
                                     None
                                 } else {
-                                    args.inptut_sets[*function_index] = composition_set_option
-                                        .clone()
-                                        .and_then(|set| Some((*mode, set)));
+                                    args.inptut_sets[*function_index] =
+                                        composition_set_option.clone().and_then(|set| {
+                                            debug_assert_ne!(
+                                                0,
+                                                set.len(),
+                                                "Expect at least 1 item in composition set"
+                                            );
+                                            Some((*mode, set))
+                                        });
                                     Some((*comp_index, *function_index))
                                 }
                             })
@@ -391,10 +397,7 @@ impl Dispatcher {
 
         // check if there are no input sets or all of them are none, then don't need sharding,
         // but still want to run if we queued it.
-        let is_sharded = input_sets.len() != 0
-            && input_sets
-                .iter()
-                .any(|opt| opt.is_some() && !opt.as_ref().unwrap().1.is_empty());
+        let is_sharded = input_sets.len() != 0 && input_sets.iter().any(|opt| opt.is_some());
         let composition_results: DandelionResult<Vec<_>> = if is_sharded {
             // TODO: check how to best compute the target parallelism
             let target_parallelism = usize::MAX;
@@ -446,11 +449,7 @@ impl Dispatcher {
                         (insert @ None, Some(set)) => {
                             *insert = Some(set);
                         }
-                        (Some(old_set), Some(new_set)) => {
-                            old_set
-                                .combine(new_set)
-                                .expect("Should always be possible to combine");
-                        }
+                        (Some(old_set), Some(new_set)) => old_set.combine(new_set),
                     }
                 }
                 accumulator
@@ -553,22 +552,7 @@ impl Dispatcher {
                         }
                     }
 
-                    let context_arc = Arc::new(context);
-                    let composition_sets = context_arc
-                        .content
-                        .iter()
-                        .enumerate()
-                        .map(|(function_set_id, data_option)| {
-                            data_option.as_ref().and_then(|_| {
-                                Some(CompositionSet::from((
-                                    function_set_id,
-                                    vec![context_arc.clone()],
-                                )))
-                            })
-                        })
-                        .collect();
-
-                    return Ok(composition_sets);
+                    return Ok(CompositionSet::from_context(context));
                 }
                 FunctionType::Composition(comp_info) => {
                     return self

--- a/dispatcher/tests/dispatcher_tests.rs
+++ b/dispatcher/tests/dispatcher_tests.rs
@@ -10,6 +10,7 @@ mod dispatcher_tests {
         function_driver::{ComputeResource, Metadata},
         machine_config::{DomainType, EngineType},
         memory_domain::{Context, ContextTrait, MemoryDomain, MemoryResource},
+        DataItem,
     };
     use std::{collections::BTreeMap, sync::Arc};
 
@@ -61,27 +62,13 @@ mod dispatcher_tests {
         return (dispatcher, function_id);
     }
 
-    fn check_matrix(context: &Context, set_id: usize, key: u32, rows: u64, expected: Vec<u64>) {
-        assert!(context.content.len() >= set_id);
-        let out_mat_set = context.content[set_id].as_ref().expect("Should have set");
-        assert_eq!(
-            1,
-            out_mat_set
-                .buffers
-                .iter()
-                .filter(|buffer| buffer.key == key)
-                .count()
-        );
-        let out_mat_position = out_mat_set
-            .buffers
-            .iter()
-            .find(|buffer| buffer.key == key)
-            .expect("should find a buffer with the correct key");
+    fn check_matrix(context: &Context, item: &DataItem, rows: u64, expected: Vec<u64>) {
+        let out_mat_position = item.data;
         let mut out_mat = Vec::<u64>::new();
-        assert_eq!((expected.len() + 1) * 8, out_mat_position.data.size);
+        assert_eq!((expected.len() + 1) * 8, out_mat_position.size);
         out_mat.resize(expected.len() + 1, 0);
         context
-            .read(out_mat_position.data.offset, &mut out_mat)
+            .read(out_mat_position.offset, &mut out_mat)
             .expect("Should read output matrix");
         assert_eq!(rows, out_mat[0]);
         let mut found_error = false;

--- a/dispatcher/tests/dispatcher_tests/function_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/function_tests.rs
@@ -77,10 +77,7 @@ pub fn single_domain_and_engine_matmul<Domain: MemoryDomain>(
         }],
     })];
 
-    let inputs = vec![Some(CompositionSet::from((
-        0,
-        vec![(Arc::new(in_context))],
-    )))];
+    let inputs = CompositionSet::from_context(in_context);
 
     let recorder = Recorder::new(zero_id(), Instant::now());
 
@@ -95,10 +92,10 @@ pub fn single_domain_and_engine_matmul<Domain: MemoryDomain>(
     assert_eq!(1, out_sets.len());
     let out_set = out_sets[0].as_ref().expect("Should have set");
     let mut out_set_iter = out_set.into_iter();
-    let (_, _, out_context) = out_set_iter.next().unwrap();
+    let (item, out_context) = out_set_iter.next().unwrap();
     assert!(out_set_iter.next().is_none());
-    assert_eq!(1, out_context.content.len());
-    check_matrix(&out_context, 0, 0, 2, vec![5, 11, 11, 25])
+    assert_eq!(0, item.key);
+    check_matrix(out_context, item, 2, vec![5, 11, 11, 25])
 }
 
 pub fn composition_single_matmul<Domain: MemoryDomain>(
@@ -146,7 +143,7 @@ pub fn composition_single_matmul<Domain: MemoryDomain>(
         }],
         output_map: BTreeMap::from([(1, 0)]),
     };
-    let inputs = vec![Some(CompositionSet::from((0, vec![Arc::new(in_context)])))];
+    let inputs = CompositionSet::from_context(in_context);
 
     let recorder = Recorder::new(zero_id(), Instant::now());
 
@@ -162,12 +159,10 @@ pub fn composition_single_matmul<Domain: MemoryDomain>(
     let out_context_list = out_contexts[0].as_mut().expect("Should have set");
 
     let mut out_context_iter = out_context_list.into_iter();
-    let (_, _, out_context) = out_context_iter.next().unwrap();
+    let (item, out_context) = out_context_iter.next().unwrap();
     assert!(out_context_iter.next().is_none());
-    assert_eq!(1, out_context.content.len());
-    let out_mat_set = out_context.content[0].as_ref().expect("Should have set");
-    assert_eq!(1, out_mat_set.buffers.len());
-    check_matrix(&out_context, 0, 0, 2, vec![5, 11, 11, 25])
+    assert_eq!(0, item.key);
+    check_matrix(&out_context, item, 2, vec![5, 11, 11, 25])
 }
 
 fn composition_option_helper(
@@ -223,7 +218,7 @@ pub fn composition_optional<Domain: MemoryDomain>(
     assert_eq!(1, out_contexts.len());
     assert!(out_contexts[0].is_none());
 
-    // check case where the set is an input set, not optional and empty
+    // check case where the set is an input set, optional and not present
     let composition2 = Composition {
         dependencies: vec![FunctionDependencies {
             function: function_id.clone(),
@@ -231,52 +226,14 @@ pub fn composition_optional<Domain: MemoryDomain>(
             input_set_ids: vec![Some(InputSetDescriptor {
                 composition_id: 0,
                 sharding: ShardingMode::All,
-                optional: false,
+                optional: true,
             })],
             output_set_ids: vec![Some(1)],
         }],
         output_map: BTreeMap::from([(1, 0)]),
     };
-    let inputs2 = vec![Some(CompositionSet::from((0, vec![])))];
+    let inputs2 = vec![None];
     let out_contexts = composition_option_helper(composition2, inputs2, &mut dispatcher);
-    assert_eq!(1, out_contexts.len());
-    assert!(out_contexts[0].is_none());
-
-    // check case where the set is an input set, optional and not present
-    let composition3 = Composition {
-        dependencies: vec![FunctionDependencies {
-            function: function_id.clone(),
-            join_info: (vec![0], vec![]),
-            input_set_ids: vec![Some(InputSetDescriptor {
-                composition_id: 0,
-                sharding: ShardingMode::All,
-                optional: true,
-            })],
-            output_set_ids: vec![Some(1)],
-        }],
-        output_map: BTreeMap::from([(1, 0)]),
-    };
-    let inputs3 = vec![None];
-    let out_contexts = composition_option_helper(composition3, inputs3, &mut dispatcher);
-    assert_eq!(1, out_contexts.len());
-    assert!(out_contexts[0].is_some());
-
-    // check case where the set is an input set, optional and empty
-    let composition4 = Composition {
-        dependencies: vec![FunctionDependencies {
-            function: function_id.clone(),
-            join_info: (vec![0], vec![]),
-            input_set_ids: vec![Some(InputSetDescriptor {
-                composition_id: 0,
-                sharding: ShardingMode::All,
-                optional: true,
-            })],
-            output_set_ids: vec![Some(1)],
-        }],
-        output_map: BTreeMap::from([(1, 0)]),
-    };
-    let inputs4 = vec![Some(CompositionSet::from((0, vec![])))];
-    let out_contexts = composition_option_helper(composition4, inputs4, &mut dispatcher);
     assert_eq!(1, out_contexts.len());
     assert!(out_contexts[0].is_some());
 
@@ -393,7 +350,7 @@ pub fn composition_parallel_matmul<Domain: MemoryDomain>(
         }],
         output_map: BTreeMap::from([(1, 0)]),
     };
-    let inputs = vec![Some(CompositionSet::from((0, vec![Arc::new(in_context)])))];
+    let inputs = CompositionSet::from_context(in_context);
 
     let recorder = Recorder::new(zero_id(), Instant::now());
 
@@ -409,20 +366,10 @@ pub fn composition_parallel_matmul<Domain: MemoryDomain>(
     let out_set = out_vec[0].as_ref().expect("Should have set");
 
     // check for each shard:
-    for (index, (_, _, matrix_context)) in out_set.into_iter().enumerate() {
-        assert!(index < 2);
-        if let Some(matrix_set) = &matrix_context.content[0] {
-            assert_eq!(1, matrix_set.buffers.len());
-            let matrix_buffer = &matrix_set.buffers[0];
-            assert!(matrix_buffer.key == 1 || matrix_buffer.key == 0);
-            check_matrix(
-                &matrix_context,
-                0,
-                matrix_buffer.key,
-                2,
-                vec![5, 11, 11, 25],
-            );
-        }
+    assert_eq!(2, out_set.len());
+    for (item, matrix_context) in out_set.into_iter() {
+        assert!(item.key == 1 || item.key == 0);
+        check_matrix(&matrix_context, item, 2, vec![5, 11, 11, 25]);
     }
 }
 
@@ -486,7 +433,7 @@ pub fn composition_chain_matmul<Domain: MemoryDomain>(
 
     let recorder = Recorder::new(zero_id(), Instant::now());
 
-    let inputs = vec![Some(CompositionSet::from((0, vec![Arc::new(in_context)])))];
+    let inputs = CompositionSet::from_context(in_context);
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
@@ -498,10 +445,10 @@ pub fn composition_chain_matmul<Domain: MemoryDomain>(
     assert_eq!(1, out_contexts.len());
     let out_composition_set = out_contexts[0].as_ref().expect("Should have set 0");
     let mut out_context_iter = out_composition_set.into_iter();
-    let (_, _, out_context) = out_context_iter.next().unwrap();
+    let (item, out_context) = out_context_iter.next().unwrap();
     assert!(out_context_iter.next().is_none());
-    assert_eq!(1, out_context.content.len());
-    check_matrix(&out_context, 0, 0, 2, vec![146, 330, 330, 746]);
+    assert_eq!(0, item.key);
+    check_matrix(&out_context, item, 2, vec![146, 330, 330, 746]);
 }
 
 pub fn composition_diamond_matmac<Domain: MemoryDomain>(
@@ -693,12 +640,7 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
 
     let recorder = Recorder::new(zero_id(), Instant::now());
 
-    let context_arc = Arc::new(in_context);
-    let inputs = vec![
-        Some(CompositionSet::from((0, vec![context_arc.clone()]))),
-        Some(CompositionSet::from((1, vec![context_arc.clone()]))),
-        Some(CompositionSet::from((2, vec![context_arc.clone()]))),
-    ];
+    let inputs = CompositionSet::from_context(in_context);
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
@@ -710,13 +652,12 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
     assert_eq!(1, out_contexts.len());
     let out_composition_set = out_contexts[0].as_ref().expect("Should have set 0");
     let mut out_context_iter = out_composition_set.into_iter();
-    let (_, _, out_context) = out_context_iter.next().unwrap();
+    let (item, out_context) = out_context_iter.next().unwrap();
     assert!(out_context_iter.next().is_none());
-    assert_eq!(1, out_context.content.len());
+    assert_eq!(0, item.key);
     check_matrix(
         &out_context,
-        0,
-        0,
+        item,
         4,
         vec![
             105, 210, 315, 525, 210, 420, 630, 1050, 315, 630, 945, 1575, 525, 1050, 1575, 2625,
@@ -840,11 +781,7 @@ pub fn composition_chain_large_matmac<Domain: MemoryDomain>(
 
     let recorder = Recorder::new(Arc::new(0.to_string()), Instant::now());
 
-    let context_arc = Arc::new(in_context);
-    let inputs = vec![
-        Some(CompositionSet::from((0, vec![context_arc.clone()]))),
-        Some(CompositionSet::from((1, vec![context_arc.clone()]))),
-    ];
+    let inputs = CompositionSet::from_context(in_context);
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
@@ -856,10 +793,10 @@ pub fn composition_chain_large_matmac<Domain: MemoryDomain>(
     assert_eq!(1, out_contexts.len());
     let out_composition_set = out_contexts[0].as_ref().expect("Should have set 0");
     let mut out_context_iter = out_composition_set.into_iter();
-    let (_, _, out_context) = out_context_iter.next().unwrap();
+    let (out_item, out_context) = out_context_iter.next().unwrap();
     assert!(out_context_iter.next().is_none());
-    assert_eq!(1, out_context.content.len());
     let expected =
         (1 + 2 * chain_length as u64..matrix_size + 1 + 2 * chain_length as u64).collect();
-    check_matrix(&out_context, 0, 0, matrix_width, expected);
+    assert_eq!(0, out_item.key);
+    check_matrix(&out_context, out_item, matrix_width, expected);
 }

--- a/dispatcher/tests/dispatcher_tests/function_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/function_tests.rs
@@ -151,12 +151,12 @@ pub fn composition_single_matmul<Domain: MemoryDomain>(
         .build()
         .unwrap()
         .block_on(dispatcher.queue_composition(composition, inputs, false, recorder));
-    let mut out_contexts = match result {
+    let out_contexts = match result {
         Ok(context) => context,
         Err(err) => panic!("Failed with: {:?}", err),
     };
     assert_eq!(1, out_contexts.len());
-    let out_context_list = out_contexts[0].as_mut().expect("Should have set");
+    let out_context_list = out_contexts[0].as_ref().expect("Should have set");
 
     let mut out_context_iter = out_context_list.into_iter();
     let (item, out_context) = out_context_iter.next().unwrap();

--- a/dispatcher/tests/dispatcher_tests/registry_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/registry_tests.rs
@@ -38,16 +38,24 @@ pub fn single_input_fixed<Domain: MemoryDomain>(
     engine_type: EngineType,
     engine_resource: Vec<ComputeResource>,
 ) {
-    let matrix_a = Box::new([1u64, 2u64]);
-    let matrix_b = Box::new([1u64, 3u64]);
-    let matrix_c = Box::new([1u64, 5u64]);
-    let fault_matrix = Box::new([1u64, 100u64]);
-    let expected = [11, 11, 17];
     // set up input sets
-    let mat_con_a = Arc::new(create_context(matrix_a));
-    let mat_con_b = Arc::new(create_context(matrix_b));
-    let mat_con_c = Arc::new(create_context(matrix_c));
-    let mat_fault = Arc::new(create_context(fault_matrix));
+    let mat_a_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 2u64])))[0]
+            .take()
+            .unwrap();
+    let mat_b_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 3u64])))[0]
+            .take()
+            .unwrap();
+    let mat_c_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 5u64])))[0]
+            .take()
+            .unwrap();
+    let mat_fault_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 100u64])))[0]
+            .take()
+            .unwrap();
+    let expected = [11, 11, 17];
     let in_set_names = vec![
         (String::from(""), None),
         (String::from(""), None),
@@ -68,7 +76,7 @@ pub fn single_input_fixed<Domain: MemoryDomain>(
     absolute_path.push(relative_path);
     for i in 0..=2 {
         let mut local_names = in_set_names.clone();
-        local_names[i].1 = Some(CompositionSet::from((0, vec![mat_con_a.clone()])));
+        local_names[i].1 = Some(mat_a_composition_set.clone());
         // alter metadata for the functions
         let function_id = Arc::new(format!("local_name_{}", i));
 
@@ -94,10 +102,10 @@ pub fn single_input_fixed<Domain: MemoryDomain>(
             .filter(|index| *index != i)
             .collect::<Vec<_>>();
         let mut inputs = vec![None; 3];
-        inputs[input_sets[0]] = Some(CompositionSet::from((0, vec![mat_con_b.clone()])));
-        inputs[input_sets[1]] = Some(CompositionSet::from((0, vec![mat_con_c.clone()])));
+        inputs[input_sets[0]] = Some(mat_b_composition_set.clone());
+        inputs[input_sets[1]] = Some(mat_c_composition_set.clone());
         let mut overwrite_inputs = inputs.clone();
-        overwrite_inputs[i] = Some(CompositionSet::from((0, vec![mat_fault.clone()])));
+        overwrite_inputs[i] = Some(mat_fault_composition_set.clone());
 
         let mut recorder = Recorder::new(function_id.clone(), Instant::now());
         let result = tokio::runtime::Builder::new_current_thread()
@@ -125,13 +133,15 @@ pub fn single_input_fixed<Domain: MemoryDomain>(
         assert_eq!(1, out_sets.len());
         assert_eq!(1, overwrite_sets.len());
         let mut result_iter = out_sets[0].as_ref().unwrap().into_iter();
-        let (_, _, result_set) = result_iter.next().unwrap();
+        let (result_item, result_set) = result_iter.next().unwrap();
         assert!(result_iter.next().is_none());
         let mut overwrite_iter = overwrite_sets[0].as_ref().unwrap().into_iter();
-        let (_, _, overwrite_set) = overwrite_iter.next().unwrap();
+        let (overwrite_item, overwrite_set) = overwrite_iter.next().unwrap();
         assert!(overwrite_iter.next().is_none());
-        check_matrix(&result_set, 0, 0, 1, vec![expected[i]]);
-        check_matrix(&overwrite_set, 0, 0, 1, vec![expected[i]]);
+        assert_eq!(0, result_item.key);
+        assert_eq!(0, overwrite_item.key);
+        check_matrix(&result_set, result_item, 1, vec![expected[i]]);
+        check_matrix(&overwrite_set, overwrite_item, 1, vec![expected[i]]);
     }
 }
 
@@ -142,16 +152,25 @@ pub fn multiple_input_fixed<Domain: MemoryDomain>(
     engine_type: EngineType,
     engine_resource: Vec<ComputeResource>,
 ) {
-    let matrix_a = Box::new([1u64, 2u64]);
-    let matrix_b = Box::new([1u64, 3u64]);
-    let matrix_c = Box::new([1u64, 5u64]);
-    let fault_matrix = Box::new([1u64, 100u64]);
-    let expected = [11, 11, 17];
     // set up input sets
-    let mat_con_a = Arc::new(create_context(matrix_a));
-    let mat_con_b = Arc::new(create_context(matrix_b));
-    let mat_con_c = Arc::new(create_context(matrix_c));
-    let mat_fault = Arc::new(create_context(fault_matrix));
+    let mat_a_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 2u64])))[0]
+            .take()
+            .unwrap();
+    let mat_b_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 3u64])))[0]
+            .take()
+            .unwrap();
+    let mat_c_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 5u64])))[0]
+            .take()
+            .unwrap();
+    let mat_fault_composition_set =
+        CompositionSet::from_context(create_context(Box::new([1u64, 100u64])))[0]
+            .take()
+            .unwrap();
+    let expected = [11, 11, 17];
+
     let in_set_names = vec![
         (String::from(""), None),
         (String::from(""), None),
@@ -176,8 +195,8 @@ pub fn multiple_input_fixed<Domain: MemoryDomain>(
             .filter(|index| *index != i)
             .collect::<Vec<_>>();
         let mut local_names = in_set_names.clone();
-        local_names[fixed_sets[0]].1 = Some(CompositionSet::from((0, vec![mat_con_b.clone()])));
-        local_names[fixed_sets[1]].1 = Some(CompositionSet::from((0, vec![mat_con_c.clone()])));
+        local_names[fixed_sets[0]].1 = Some(mat_b_composition_set.clone());
+        local_names[fixed_sets[1]].1 = Some(mat_c_composition_set.clone());
         // alter metadata for the functions
         let function_id = Arc::new(format!("insert_function_{}", i));
 
@@ -199,10 +218,10 @@ pub fn multiple_input_fixed<Domain: MemoryDomain>(
 
         // prepare inputs
         let mut inputs = vec![None; 3];
-        inputs[i] = Some(CompositionSet::from((0, vec![mat_con_a.clone()])));
+        inputs[i] = Some(mat_a_composition_set.clone());
         let mut overwrite_inputs = inputs.clone();
-        overwrite_inputs[fixed_sets[0]] = Some(CompositionSet::from((0, vec![mat_fault.clone()])));
-        overwrite_inputs[fixed_sets[1]] = Some(CompositionSet::from((0, vec![mat_fault.clone()])));
+        overwrite_inputs[fixed_sets[0]] = Some(mat_fault_composition_set.clone());
+        overwrite_inputs[fixed_sets[1]] = Some(mat_fault_composition_set.clone());
 
         let mut recorder = Recorder::new(function_id.clone(), Instant::now());
         let result = tokio::runtime::Builder::new_current_thread()
@@ -230,13 +249,15 @@ pub fn multiple_input_fixed<Domain: MemoryDomain>(
         assert_eq!(1, out_sets.len());
         assert_eq!(1, overwrite_sets.len());
         let mut result_iter = out_sets[0].as_ref().unwrap().into_iter();
-        let (_, _, result_set) = result_iter.next().unwrap();
+        let (result_item, result_set) = result_iter.next().unwrap();
         assert!(result_iter.next().is_none());
         let mut overwrite_iter = overwrite_sets[0].as_ref().unwrap().into_iter();
-        let (_, _, overwrite_set) = overwrite_iter.next().unwrap();
+        let (overwrite_item, overwrite_set) = overwrite_iter.next().unwrap();
         assert!(overwrite_iter.next().is_none());
-        check_matrix(&result_set, 0, 0, 1, vec![expected[i]]);
-        check_matrix(&overwrite_set, 0, 0, 1, vec![expected[i]]);
+        assert_eq!(0, result_item.key);
+        assert_eq!(0, overwrite_item.key);
+        check_matrix(&result_set, result_item, 1, vec![expected[i]]);
+        check_matrix(&overwrite_set, overwrite_item, 1, vec![expected[i]]);
     }
 }
 

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -98,7 +98,8 @@ impl JoinStrategy {
 /// By construction, empty sets should not be allowed to exist, as they should return None instead on construction
 #[derive(Clone, Debug)]
 pub struct CompositionSet {
-    /// items identfied by tuple of key, item index and the context reference
+    /// Each tuple in the list contains the DataItem with the metadata and the Context in which the item is stored.
+    /// The data: Position of the DataItem refers to offset and size within the Context.
     item_list: Vec<(DataItem, Arc<Context>)>,
     set_name: String,
 }
@@ -190,26 +191,21 @@ impl CompositionSet {
     }
 }
 
-pub struct CompositionSetTransferIterator<'origin> {
-    /// set for which this iterator is implemented
-    set_iterator: std::slice::Iter<'origin, (DataItem, Arc<Context>)>,
-}
-
-impl<'origin> Iterator for CompositionSetTransferIterator<'origin> {
+/// Iterator over a reference of the composition set, not taking ownership
+impl<'origin> IntoIterator for &'origin CompositionSet {
     type Item = &'origin (DataItem, Arc<Context>);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.set_iterator.next()
+    type IntoIter = std::slice::Iter<'origin, (DataItem, Arc<Context>)>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.item_list.iter()
     }
 }
 
-impl<'origin> IntoIterator for &'origin CompositionSet {
-    type Item = &'origin (DataItem, Arc<Context>);
-    type IntoIter = CompositionSetTransferIterator<'origin>;
+/// Iterator taking ownership of the Compositon set
+impl IntoIterator for CompositionSet {
+    type Item = (DataItem, Arc<Context>);
+    type IntoIter = std::vec::IntoIter<(DataItem, Arc<Context>)>;
     fn into_iter(self) -> Self::IntoIter {
-        Self::IntoIter {
-            set_iterator: self.item_list.iter(),
-        }
+        self.item_list.into_iter()
     }
 }
 

--- a/machine_interface/src/composition.rs
+++ b/machine_interface/src/composition.rs
@@ -1,11 +1,10 @@
 use crate::{
     composition::join_iterator::JoinIterator,
     memory_domain::{Context, ContextTrait},
+    DataItem, DataSet, Position,
 };
 use core::fmt;
-use dandelion_commons::{
-    err_dandelion, DandelionError, DandelionResult, DispatcherError, FunctionId,
-};
+use dandelion_commons::FunctionId;
 use log::trace;
 use std::{cmp, collections::BTreeMap, sync::Arc, vec};
 
@@ -95,100 +94,121 @@ impl JoinStrategy {
 }
 
 /// Struct that has all locations belonging to one set, that is potentially spread over multiple contexts.
+/// Should only be constructed from a context, returning a list of all sets in the contexts content.
+/// By construction, empty sets should not be allowed to exist, as they should return None instead on construction
 #[derive(Clone, Debug)]
 pub struct CompositionSet {
     /// items identfied by tuple of key, item index and the context reference
-    item_list: Vec<(u32, usize, Arc<Context>)>,
-    /// the set side inside the contexts the composition set represents
-    set_index: usize,
+    item_list: Vec<(DataItem, Arc<Context>)>,
+    set_name: String,
 }
 
 impl CompositionSet {
-    pub fn is_empty(&self) -> bool {
-        self.item_list.is_empty()
-    }
-
     pub fn len(&self) -> usize {
         self.item_list.len()
     }
 
-    pub fn get_set_idx(&self) -> usize {
-        self.set_index
+    pub fn get_name(&self) -> &String {
+        &self.set_name
     }
 
     /// Used for serializing the data to protobuf
     pub fn get_item(&self, idx: usize) -> (String, u32, Vec<u8>) {
-        let item = &self.item_list[idx];
-        let context_item = &item.2.content[self.set_index].as_ref().unwrap().buffers[item.1];
-        let mut data_bytes = Vec::<u8>::with_capacity(context_item.data.size);
-        let data_slice = item
-            .2
-            .get_chunk_ref(context_item.data.offset, context_item.data.size)
-            .expect("Failed to read item!");
-        data_bytes.extend_from_slice(data_slice);
-        (context_item.ident.clone(), context_item.key, data_bytes)
-    }
-
-    pub fn combine(&mut self, additional: CompositionSet) -> DandelionResult<()> {
-        let CompositionSet {
-            item_list,
-            set_index,
-        } = additional;
-        if self.set_index != set_index {
-            return err_dandelion!(DandelionError::Dispatcher(
-                DispatcherError::CompositionCombine,
-            ));
+        let (item, context) = &self.item_list[idx];
+        let Position { offset, size } = item.data;
+        let mut data_bytes = Vec::<u8>::with_capacity(size);
+        while data_bytes.len() < size {
+            let data_slice = context
+                .get_chunk_ref(offset + data_bytes.len(), size - data_bytes.len())
+                .expect("Failed to read item!");
+            data_bytes.extend_from_slice(data_slice);
         }
-        self.item_list.extend(item_list.into_iter());
-        self.item_list.sort_unstable_by_key(|a| a.0);
-        return Ok(());
+        (item.ident.clone(), item.key, data_bytes)
     }
-}
 
-impl From<(usize, Vec<Arc<Context>>)> for CompositionSet {
-    fn from(pair: (usize, Vec<Arc<Context>>)) -> Self {
-        let (set_index, context_vec) = pair;
-        let mut item_list = Vec::new();
-        for context in context_vec.into_iter() {
-            if let Some(Some(set)) = context.content.get(set_index) {
-                for (item_index, buffer) in set.buffers.iter().enumerate() {
-                    item_list.push((buffer.key, item_index, context.clone()));
+    pub fn from_context(mut context: Context) -> Vec<Option<Self>> {
+        // take the content from the context before putting it into an arc
+        let sets = core::mem::take(&mut context.content);
+        let context_arc = Arc::new(context);
+        let mut composition_sets = Vec::with_capacity(sets.len());
+        for set_option in sets.into_iter() {
+            let composition_option = if let Some(set) = set_option {
+                let DataSet { ident, buffers } = set;
+                if buffers.len() == 0 {
+                    None
+                } else {
+                    let mut item_list = Vec::with_capacity(buffers.len());
+                    for item in buffers.into_iter() {
+                        item_list.push((item, context_arc.clone()));
+                    }
+                    Some(CompositionSet {
+                        item_list,
+                        set_name: ident,
+                    })
                 }
-            }
+            } else {
+                None
+            };
+            composition_sets.push(composition_option);
         }
-        item_list.sort_unstable_by_key(|a| a.0);
-        return CompositionSet {
-            item_list,
-            set_index,
-        };
+        composition_sets
+    }
+
+    // This is used on the frontend, to be depricated when we change function registration serialziation
+    // DO NOT ADD USAGE
+    pub fn from_byte_items(items: Vec<(String, Vec<u8>)>) -> Self {
+        CompositionSet {
+            item_list: items
+                .into_iter()
+                .map(|(name, data)| {
+                    (
+                        DataItem {
+                            ident: name,
+                            data: Position {
+                                offset: 0,
+                                size: data.len(),
+                            },
+                            key: 0,
+                        },
+                        Arc::new(
+                            crate::memory_domain::read_only::ReadOnlyContext::new(
+                                data.into_boxed_slice(),
+                            )
+                            .unwrap(),
+                        ),
+                    )
+                })
+                .collect(),
+            // This is only used for static sets from function registration, which will get a name from the metadata
+            set_name: String::new(),
+        }
+    }
+
+    pub fn combine(&mut self, additional: CompositionSet) {
+        self.item_list.extend(additional.item_list.into_iter());
+        self.item_list.sort_unstable_by_key(|a| a.0.key);
     }
 }
 
 pub struct CompositionSetTransferIterator<'origin> {
     /// set for which this iterator is implemented
-    set_iterator: std::slice::Iter<'origin, (u32, usize, Arc<Context>)>,
-    set_index: usize,
+    set_iterator: std::slice::Iter<'origin, (DataItem, Arc<Context>)>,
 }
 
-impl Iterator for CompositionSetTransferIterator<'_> {
-    type Item = (usize, usize, Arc<Context>);
+impl<'origin> Iterator for CompositionSetTransferIterator<'origin> {
+    type Item = &'origin (DataItem, Arc<Context>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.set_iterator
-            .next()
-            .and_then(|(_, item_index, context)| {
-                Some((self.set_index, *item_index, context.clone()))
-            })
+        self.set_iterator.next()
     }
 }
 
 impl<'origin> IntoIterator for &'origin CompositionSet {
-    type Item = (usize, usize, Arc<Context>);
+    type Item = &'origin (DataItem, Arc<Context>);
     type IntoIter = CompositionSetTransferIterator<'origin>;
     fn into_iter(self) -> Self::IntoIter {
         Self::IntoIter {
             set_iterator: self.item_list.iter(),
-            set_index: self.set_index,
         }
     }
 }
@@ -196,15 +216,15 @@ impl<'origin> IntoIterator for &'origin CompositionSet {
 /// A more concise display for the composition set that does not print the entire Context contents.
 impl fmt::Display for CompositionSet {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "item_index: [")?;
-        for (key, itm_idx, ctx) in self.item_list.iter() {
+        write!(f, "items: [")?;
+        for (item, ctx) in self.item_list.iter() {
             write!(
                 f,
-                "(key: {}, idx: {}, context: {{ type: {:?}, size: {}, state: {:?} }})",
-                key, itm_idx, ctx.context, ctx.size, ctx.state
+                "(item: {:?}, context: {{ type: {:?}, size: {}, state: {:?} }})",
+                item, ctx.context, ctx.size, ctx.state
             )?;
         }
-        write!(f, "], set_index: {}", self.set_index)
+        write!(f, "]")
     }
 }
 
@@ -438,12 +458,21 @@ fn create_dummy_set(keys: Vec<u32>) -> CompositionSet {
     let items = keys
         .into_iter()
         .enumerate()
-        .map(|(i, k)| (k, i, dummy_context.clone()))
-        .sorted_by_key(|tuple| tuple.0)
+        .map(|(i, k)| {
+            (
+                DataItem {
+                    ident: i.to_string(),
+                    key: k,
+                    data: Position { offset: 0, size: 0 },
+                },
+                dummy_context.clone(),
+            )
+        })
+        .sorted_by_key(|tuple| tuple.0.key)
         .collect();
     CompositionSet {
         item_list: items,
-        set_index: 0,
+        set_name: String::new(),
     }
 }
 
@@ -489,18 +518,20 @@ fn check_sharding(actual: Vec<Vec<Option<CompositionSet>>>, expected: Vec<SetGro
             let mut actual_set = actual_set_opt.unwrap();
             assert_eq!(expected_set.len(), actual_set.item_list.len());
             // sort both lists by item index, since that one should be unique, since we only have a single context
-            expected_set.sort_by_key(|item| item.1);
-            actual_set.item_list.sort_by_key(|item| item.1);
+            expected_set.sort_by_key(|item| item.1.clone());
+            actual_set.item_list.sort_by_key(|item| item.0.key);
             // have two sorted lists, check that each item index is the expected one and that it has the correct key
-            for ((expected_key, expected_index), (actual_key, actual_index, _)) in
+            for ((expected_key, expected_ident), (actual_item, _)) in
                 expected_set.into_iter().zip(actual_set.item_list)
             {
                 assert_eq!(
-                    expected_index, actual_index,
+                    expected_ident.to_string(),
+                    actual_item.ident,
                     "for keys {}, {}",
-                    expected_key, actual_key
+                    expected_key,
+                    actual_item.ident
                 );
-                assert_eq!(expected_key, actual_key);
+                assert_eq!(expected_key, actual_item.key);
             }
         }
     }
@@ -516,8 +547,8 @@ fn print_sharding(actual: &Vec<Vec<Option<CompositionSet>>>) {
                 println!("  set {}: [None]", set_idx);
             } else {
                 print!("  set {}: [ ", set_idx);
-                for (key, itm, _) in set.as_ref().unwrap().item_list.iter() {
-                    print!("({}, {}) ", key, itm);
+                for (item, _) in set.as_ref().unwrap().item_list.iter() {
+                    print!("{:?} ", item);
                 }
                 println!("]");
             }
@@ -1002,13 +1033,13 @@ fn join_it_any_chain_test_6() {
     assert_eq!(sharding_2[0][1].as_ref().unwrap().len(), 2);
     assert_eq!(sharding_2[0][2].as_ref().unwrap().len(), 1);
     assert_eq!(sharding_2[0][3].as_ref().unwrap().len(), 1); // <- parallelized any set
-    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[0].0, 0);
-    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[1].0, 1);
-    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[2].0, 4);
-    assert_eq!(sharding_2[0][1].as_ref().unwrap().item_list[0].0, 0);
-    assert_eq!(sharding_2[0][1].as_ref().unwrap().item_list[1].0, 0);
-    assert_eq!(sharding_2[0][2].as_ref().unwrap().item_list[0].0, 0);
-    assert_eq!(sharding_2[0][3].as_ref().unwrap().item_list[0].0, 5);
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[0].0.key, 0);
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[1].0.key, 1);
+    assert_eq!(sharding_2[0][0].as_ref().unwrap().item_list[2].0.key, 4);
+    assert_eq!(sharding_2[0][1].as_ref().unwrap().item_list[0].0.key, 0);
+    assert_eq!(sharding_2[0][1].as_ref().unwrap().item_list[1].0.key, 0);
+    assert_eq!(sharding_2[0][2].as_ref().unwrap().item_list[0].0.key, 0);
+    assert_eq!(sharding_2[0][3].as_ref().unwrap().item_list[0].0.key, 5);
 
     let sharding_3 = get_sharding(sets.clone(), join_order.clone(), join_strategies.clone(), 3);
     assert_eq!(sharding_3.len(), 3); // <- should get 3 shardings
@@ -1017,12 +1048,12 @@ fn join_it_any_chain_test_6() {
     assert_eq!(sharding_3[0][1].as_ref().unwrap().len(), 2); // <- parallelized any set
     assert_eq!(sharding_3[0][2].as_ref().unwrap().len(), 1); // <- parallelized any set
     assert_eq!(sharding_3[0][3].as_ref().unwrap().len(), 2);
-    assert_eq!(sharding_3[0][0].as_ref().unwrap().item_list[0].0, 0);
-    assert_eq!(sharding_3[0][1].as_ref().unwrap().item_list[0].0, 0);
-    assert_eq!(sharding_3[0][1].as_ref().unwrap().item_list[1].0, 0);
-    assert_eq!(sharding_3[0][2].as_ref().unwrap().item_list[0].0, 0);
-    assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[0].0, 5);
-    assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[1].0, 5);
+    assert_eq!(sharding_3[0][0].as_ref().unwrap().item_list[0].0.key, 0);
+    assert_eq!(sharding_3[0][1].as_ref().unwrap().item_list[0].0.key, 0);
+    assert_eq!(sharding_3[0][1].as_ref().unwrap().item_list[1].0.key, 0);
+    assert_eq!(sharding_3[0][2].as_ref().unwrap().item_list[0].0.key, 0);
+    assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[0].0.key, 5);
+    assert_eq!(sharding_3[0][3].as_ref().unwrap().item_list[1].0.key, 5);
 }
 
 #[test]
@@ -1047,6 +1078,6 @@ fn join_it_any_chain_test_7() {
     assert_eq!(sharding[0][0].as_ref().unwrap().len(), 1);
     assert_eq!(sharding[0][1].as_ref().unwrap().len(), 1);
     assert!(sharding[0][2].is_none());
-    assert_eq!(sharding[0][0].as_ref().unwrap().item_list[0].0, 0);
-    assert_eq!(sharding[0][1].as_ref().unwrap().item_list[0].0, 0);
+    assert_eq!(sharding[0][0].as_ref().unwrap().item_list[0].0.key, 0);
+    assert_eq!(sharding[0][1].as_ref().unwrap().item_list[0].0.key, 0);
 }

--- a/machine_interface/src/composition/join_iterator.rs
+++ b/machine_interface/src/composition/join_iterator.rs
@@ -31,9 +31,8 @@ impl SetAllIterator {
         set: CompositionSet,
         write_idx: usize,
     ) -> Option<Box<dyn JoinIterator>> {
-        if set.is_empty() {
-            return left;
-        }
+        // Composition sets should be guaranteed to have at least 1 item in them
+        debug_assert_ne!(0, set.len());
 
         Some(Box::new(Self {
             left,
@@ -82,9 +81,8 @@ impl SetEachIterator {
         set: CompositionSet,
         write_idx: usize,
     ) -> (Option<Box<dyn JoinIterator>>, usize) {
-        if set.is_empty() {
-            return (left, 1);
-        }
+        // Composition sets should be guaranteed to have at least 1 item in them
+        debug_assert_ne!(0, set.len());
 
         let num_items = set.len();
         let it: Option<Box<dyn JoinIterator>> = Some(Box::new(Self {
@@ -110,7 +108,9 @@ impl JoinIterator for SetEachIterator {
         debug_assert!(self.item_idx < self.set.item_list.len());
         to_fill[self.write_idx] = Some(CompositionSet {
             item_list: vec![self.set.item_list[self.item_idx].clone()],
-            set_index: self.set.set_index,
+            // no need to clone the original set name, sharding is for functions that are to be run.
+            // When the function is run, the set names from the metadata are used, so this would be ignored anyway
+            set_name: String::new(),
         });
         if let Some(left) = &mut self.left {
             left.fill_in(to_fill);
@@ -217,8 +217,8 @@ impl SetKeyIterator {
     ) -> Option<Box<SetKeyIterator>> {
         let mut key_groups = Vec::new();
         let mut start_idx = 0;
-        for chunk in set.item_list.chunk_by(|a, b| a.0 == b.0) {
-            let key = chunk[0].0;
+        for chunk in set.item_list.chunk_by(|a, b| a.0.key == b.0.key) {
+            let key = chunk[0].0.key;
             let end_idx = start_idx + chunk.len();
             key_groups.push((key, start_idx..end_idx));
             start_idx = end_idx;
@@ -316,7 +316,9 @@ impl JoinIterator for SetKeyIterator {
             to_fill[self.write_idx] = Some(CompositionSet {
                 item_list: self.set.item_list[self.key_groups[self.key_groups_idx].1.clone()]
                     .to_vec(),
-                set_index: self.set.set_index,
+                // no need to clone the original set name, sharding is for functions that are to be run.
+                // When the function is run, the set names from the metadata are used, so this would be ignored anyway
+                set_name: String::new(),
             });
         }
         if let Some(left) = &mut self.left {
@@ -626,7 +628,7 @@ impl JoinIterator for AnyIterator {
                 for i in start_idx..end_idx {
                     if let Some(set) = &mut curr_set {
                         if let Some(next_set) = self.set_groups[i][set_idx].take() {
-                            set.combine(next_set).unwrap();
+                            set.combine(next_set);
                         }
                     } else {
                         curr_set = self.set_groups[i][set_idx].take();

--- a/machine_interface/src/function_driver/compute_driver/compute_driver_tests.rs
+++ b/machine_interface/src/function_driver/compute_driver/compute_driver_tests.rs
@@ -171,8 +171,7 @@ mod compute_driver_tests {
                 key: 0,
             }],
         }));
-        let context_arc = Arc::new(input_context);
-        let input_sets = vec![Some(CompositionSet::from((0, vec![context_arc])))];
+        let input_sets = CompositionSet::from_context(input_context);
 
         let metadata = Arc::new(Metadata {
             input_sets: vec![("".to_string(), None)],
@@ -265,8 +264,7 @@ mod compute_driver_tests {
                     key: 0,
                 }],
             })];
-            let context_arc = Arc::new(input_context);
-            let input_sets = vec![Some(CompositionSet::from((0, vec![context_arc])))];
+            let input_sets = CompositionSet::from_context(input_context);
 
             let metadata = Arc::new(Metadata {
                 input_sets: vec![("".to_string(), None)],
@@ -373,8 +371,7 @@ mod compute_driver_tests {
             ReadOnlyContext::new(unsafe { in_data.as_mut_vec() }.clone().into_boxed_slice())
                 .unwrap();
         input_context.content = content;
-        let context_arc = Arc::new(input_context);
-        let input_sets = vec![Some(CompositionSet::from((0, vec![context_arc])))];
+        let input_sets = CompositionSet::from_context(input_context);
 
         let metadata = Arc::new(Metadata {
             input_sets: vec![("stdio".to_string(), None)],
@@ -533,11 +530,7 @@ mod compute_driver_tests {
             ReadOnlyContext::new(unsafe { in_data.as_mut_vec() }.clone().into_boxed_slice())
                 .unwrap();
         input_context.content = content;
-        let context_arc = Arc::new(input_context);
-        let input_sets = vec![
-            Some(CompositionSet::from((0, vec![context_arc.clone()]))),
-            Some(CompositionSet::from((1, vec![context_arc]))),
-        ];
+        let input_sets = CompositionSet::from_context(input_context);
 
         let metadata = Arc::new(Metadata {
             input_sets: vec![("in".to_string(), None), ("in_nested".to_string(), None)],

--- a/machine_interface/src/function_driver/functions.rs
+++ b/machine_interface/src/function_driver/functions.rs
@@ -57,7 +57,7 @@ impl Function {
     ) -> DandelionResult<Context> {
         return match &self.config {
             FunctionConfig::ElfConfig(_) => {
-                load_static(domain, self.context.clone(), &self.requirements, ctx_size)
+                load_static(domain, &self.context, &self.requirements, ctx_size)
             }
             FunctionConfig::SysConfig(_) => domain.acquire_context(ctx_size),
         };

--- a/machine_interface/src/function_driver/load_utils.rs
+++ b/machine_interface/src/function_driver/load_utils.rs
@@ -23,7 +23,7 @@ pub fn load_u8_from_file(full_path: String) -> DandelionResult<Vec<u8>> {
 
 pub fn load_static(
     domain: &Box<dyn MemoryDomain>,
-    static_context: Arc<Context>,
+    static_context: &Arc<Context>,
     requirement_list: &DataRequirementList,
     ctx_size: usize,
 ) -> DandelionResult<Context> {
@@ -51,7 +51,7 @@ pub fn load_static(
         }
         transfer_memory(
             &mut function_context,
-            static_context.clone(),
+            static_context,
             requirement.offset,
             position.offset,
             position.size,

--- a/machine_interface/src/function_driver/system_driver/reqwest.rs
+++ b/machine_interface/src/function_driver/system_driver/reqwest.rs
@@ -273,8 +273,7 @@ fn parse_requests<RequestType: Request>(
 ) -> DandelionResult<Vec<RequestType>> {
     let request_info: DandelionResult<Vec<RequestType>> = composition_set
         .into_iter()
-        .map(|(set_index, item_index, context)| {
-            let data_item = &context.content[set_index].as_ref().unwrap().buffers[item_index];
+        .map(|(data_item, context)| {
             let mut request_buffer = Vec::with_capacity(data_item.data.size);
             request_buffer.resize(data_item.data.size, 0);
             context.read(data_item.data.offset, &mut request_buffer)?;

--- a/machine_interface/src/function_driver/system_driver/reqwest.rs
+++ b/machine_interface/src/function_driver/system_driver/reqwest.rs
@@ -269,7 +269,7 @@ impl Request for MemcachedRequest {
 }
 
 fn parse_requests<RequestType: Request>(
-    composition_set: &CompositionSet,
+    composition_set: CompositionSet,
 ) -> DandelionResult<Vec<RequestType>> {
     let request_info: DandelionResult<Vec<RequestType>> = composition_set
         .into_iter()
@@ -278,7 +278,7 @@ fn parse_requests<RequestType: Request>(
             request_buffer.resize(data_item.data.size, 0);
             context.read(data_item.data.offset, &mut request_buffer)?;
             // TODO: from raw may also take the vec of refs from the context (via the get_chunk interface), so we don't need to copy the request
-            RequestType::from_raw(request_buffer, data_item.ident.clone(), data_item.key)
+            RequestType::from_raw(request_buffer, data_item.ident, data_item.key)
         })
         .collect();
     return request_info;
@@ -532,7 +532,7 @@ async fn run_http_request(
     debt: Debt,
     recorder: Recorder,
 ) -> () {
-    let request_vec = match parse_requests(&composition_set) {
+    let request_vec = match parse_requests(composition_set) {
         Ok(request) => request,
         Err(err) => {
             debt.fulfill(Err(err));
@@ -563,16 +563,13 @@ async fn run_memcached_request(
     debt: Debt,
     recorder: Recorder,
 ) -> () {
-    let request_vec = match parse_requests(&composition_set) {
+    let request_vec = match parse_requests(composition_set) {
         Ok(request) => request,
         Err(err) => {
             debt.fulfill(Err(err));
             return;
         }
     };
-
-    // get rid of systems context to drop references to old contexts before starting to do requests
-    drop(composition_set);
 
     let responses = match futures::future::try_join_all(
         request_vec

--- a/machine_interface/src/function_driver/system_driver/system_driver_tests.rs
+++ b/machine_interface/src/function_driver/system_driver/system_driver_tests.rs
@@ -106,10 +106,7 @@ mod system_driver_tests {
                 key: 0,
             }],
         }));
-        let input_sets = vec![Some(CompositionSet::from((
-            0,
-            vec![Arc::new(input_context)],
-        )))];
+        let input_sets = CompositionSet::from_context(input_context);
 
         let recorder = Recorder::new(zero_id(), Instant::now());
         let metadata = Arc::new(Metadata {
@@ -202,10 +199,7 @@ dolore magna aliquyam erat, sed diam voluptua."#,
                 key: 0,
             }],
         }));
-        let input_sets = vec![Some(CompositionSet::from((
-            0,
-            vec![Arc::new(input_context)],
-        )))];
+        let input_sets = CompositionSet::from_context(input_context);
 
         let recorder = Recorder::new(zero_id(), Instant::now());
         let metadata = Arc::new(Metadata {

--- a/machine_interface/src/function_driver/thread_utils.rs
+++ b/machine_interface/src/function_driver/thread_utils.rs
@@ -95,15 +95,13 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                         buffers: Vec::with_capacity(capacity),
                     }));
                     if let Some(transfer_set) = transfer_option {
-                        for (source_set_index, source_item_index, source_context) in transfer_set {
+                        for (source_item, source_context) in transfer_set {
                             let transfer_result = memory_domain::transfer_data_item(
                                 &mut function_context,
                                 source_context,
                                 set_index,
                                 128,
-                                input_set_name.as_str(),
-                                source_set_index,
-                                source_item_index,
+                                source_item,
                             );
 
                             if let Err(transfer_error) = transfer_result {

--- a/machine_interface/src/memory_domain.rs
+++ b/machine_interface/src/memory_domain.rs
@@ -12,7 +12,7 @@ pub mod read_only;
 pub(crate) mod system_domain;
 
 use crate::{DataItem, DataSet, Position};
-use dandelion_commons::{dandelion_err, err_dandelion, DandelionError, DandelionResult};
+use dandelion_commons::{err_dandelion, DandelionError, DandelionResult};
 use std::sync::Arc;
 
 pub trait ContextTrait: Send + Sync {
@@ -251,7 +251,7 @@ pub trait MemoryDomain: Sync + Send {
 // Code to specialize transfers between different domains
 pub fn transfer_memory(
     destination: &mut Context,
-    source: Arc<Context>,
+    source: &Arc<Context>,
     destination_offset: usize,
     source_offset: usize,
     size: usize,
@@ -335,34 +335,15 @@ pub fn transfer_memory(
 }
 
 /// Transfer a data item from one context to another.
-/// If the destination does not yet have a set at the index,
-/// a new one is created using the set name given.
+/// Assumes the destination set does already exist
 pub fn transfer_data_item(
     destination: &mut Context,
-    source: Arc<Context>,
+    source: &Arc<Context>,
     destination_set_index: usize,
     destination_allignment: usize,
-    destination_set_name: &str,
-    source_set_index: usize,
-    source_item_index: usize,
+    source_item: &DataItem,
 ) -> DandelionResult<()> {
-    // check if source has item
-    if source.content.len() <= source_set_index {
-        return err_dandelion!(DandelionError::TransferInputNoSetAvailable);
-    }
-    let source_set = source.content[source_set_index]
-        .as_ref()
-        .ok_or(dandelion_err!(DandelionError::EmptyDataSet))?;
-    if source_set.buffers.len() <= source_item_index {
-        return err_dandelion!(DandelionError::TransferInputNoSetAvailable);
-    }
-
-    if destination.content.len() <= destination_set_index {
-        destination
-            .content
-            .resize_with(destination_set_index + 1, || None)
-    }
-    let source_item = &source_set.buffers[source_item_index];
+    assert!(destination_set_index < destination.content.len());
 
     log::debug!(
         "Transfering data item from {:?} into context with occupation: {:?}",
@@ -399,12 +380,7 @@ pub fn transfer_data_item(
     );
 
     {
-        let destination_set =
-            &mut destination.content[destination_set_index].get_or_insert(DataSet {
-                ident: destination_set_name.to_string(),
-                buffers: vec![],
-            });
-
+        let destination_set = destination.content[destination_set_index].as_mut().unwrap();
         destination_set.buffers.push(DataItem {
             ident: source_item.ident.clone(),
             data: Position {
@@ -413,14 +389,13 @@ pub fn transfer_data_item(
             },
             key: source_item.key,
         });
-    }
 
-    log::trace!(
-        "transfering item {} from set {} to set {}",
-        source_item.ident,
-        source_set.ident,
-        destination_set_name
-    );
+        log::trace!(
+            "transfering item {} to set {}",
+            source_item.ident,
+            destination_set.ident
+        );
+    }
 
     let source_offset = source_item.data.offset;
     let source_size = source_item.data.size;
@@ -430,8 +405,7 @@ pub fn transfer_data_item(
         destination_offset,
         source_offset,
         source_size,
-    )?;
-    Ok(())
+    )
 }
 
 #[cfg(any(test, feature = "test_export"))]

--- a/machine_interface/src/memory_domain/domain_tests.rs
+++ b/machine_interface/src/memory_domain/domain_tests.rs
@@ -104,7 +104,7 @@ fn read_system_context(
     size: usize,
     expect_success: bool,
 ) {
-    let _ = transfer_memory(system_ctx, Arc::from(base_ctx), 0, 0, system_ctx.size);
+    let _ = transfer_memory(system_ctx, &Arc::from(base_ctx), 0, 0, system_ctx.size);
 
     let mut read_buffer = vec![0; size];
     let read_error = system_ctx.read(offset, &mut read_buffer);
@@ -151,7 +151,7 @@ fn get_chunks_system_context(
     size: usize,
     expect_success: bool,
 ) {
-    let _ = transfer_memory(system_ctx, Arc::from(base_ctx), 0, 0, system_ctx.size);
+    let _ = transfer_memory(system_ctx, &Arc::from(base_ctx), 0, 0, system_ctx.size);
 
     let mut total_read = 0usize;
     while total_read < size {
@@ -199,7 +199,7 @@ fn transfer(mut source: Context, mut destination: Context) {
         .write(0, &vec![BYTEPATTERN; size])
         .expect("Writing should succeed");
     let source_ctxt_arc = Arc::new(source);
-    transfer_memory(&mut destination, source_ctxt_arc, 0, 0, size)
+    transfer_memory(&mut destination, &source_ctxt_arc, 0, 0, size)
         .expect("Should successfully transfer");
     let mut read_buffer = vec![0; size];
     destination
@@ -219,39 +219,33 @@ fn transfer_item(
     mut destination: Context,
     offset: usize,
     item_size: usize,
-    source_index: usize,
     destination_index: usize,
     expect_result: DandelionResult<()>,
 ) {
     source
         .write(offset, &vec![BYTEPATTERN; item_size])
         .expect("Writing should succeed");
-    if source.content.len() <= source_index {
-        source.content.resize_with(source_index + 1, || None);
-    }
-    source.content[source_index] = Some(crate::DataSet {
-        ident: String::from(""),
-        buffers: vec![crate::DataItem {
+
+    // make sure the destination set exists
+    destination.content.resize_with(destination_index + 1, || {
+        Some(crate::DataSet {
+            ident: String::from(""),
+            buffers: vec![],
+        })
+    });
+    let transfer_error = transfer_data_item(
+        &mut destination,
+        &Arc::new(source),
+        destination_index,
+        8,
+        &crate::DataItem {
             ident: String::from(""),
             data: crate::Position {
                 offset: offset,
                 size: item_size,
             },
             key: 0,
-        }],
-    });
-    destination.content.push(Some(crate::DataSet {
-        ident: String::from(""),
-        buffers: vec![],
-    }));
-    let transfer_error = transfer_data_item(
-        &mut destination,
-        Arc::new(source),
-        destination_index,
-        8,
-        "",
-        source_index,
-        0,
+        },
     );
     assert_eq!(transfer_error, expect_result);
     if expect_result.is_err() {
@@ -306,7 +300,7 @@ fn write_after_transfer(mut source: Context, mut destination: Context, chunck_si
     // transfer two chuncks and write overlapping with the start of the the fist one
     transfer_memory(
         &mut destination,
-        source_ctxt_arc.clone(),
+        &source_ctxt_arc,
         chunck_size,
         chunck_size,
         2 * chunck_size,
@@ -338,7 +332,7 @@ fn write_after_transfer(mut source: Context, mut destination: Context, chunck_si
     // write into and over the end of the of the second chunck
     transfer_memory(
         &mut destination,
-        source_ctxt_arc.clone(),
+        &source_ctxt_arc,
         test_offset,
         test_offset,
         2 * chunck_size,
@@ -371,7 +365,7 @@ fn write_after_transfer(mut source: Context, mut destination: Context, chunck_si
     // transfer 3 chuncks, write into the middle of the middle one
     transfer_memory(
         &mut destination,
-        source_ctxt_arc.clone(),
+        &source_ctxt_arc,
         test_offset,
         test_offset,
         3 * chunck_size,
@@ -404,7 +398,7 @@ fn write_after_transfer(mut source: Context, mut destination: Context, chunck_si
     // transfer 1 chunk write right after the end of the chunk
     transfer_memory(
         &mut destination,
-        source_ctxt_arc.clone(),
+        &source_ctxt_arc,
         test_offset,
         size - chunck_size,
         chunck_size,
@@ -521,7 +515,7 @@ macro_rules! domainTests {
             fn test_transfer_dataitem_item() {
                 let source = acquire::<$domain>($init, 4096);
                 let destination = acquire::<$domain>($init, 4096);
-                transfer_item(source, destination, 0, 128, 1, 2, Ok(()));
+                transfer_item(source, destination, 0, 128, 2, Ok(()));
             }
             #[test_log::test]
             fn test_write_after_transfer() {
@@ -544,7 +538,7 @@ macro_rules! systemsDomainTests {
             fn testing_transfer_system_context() {
                 let source = acquire::<$domain>($init, 4096);
                 let destination = acquire::<SystemMemoryDomain>($init, 4096);
-                transfer_item(source, destination, 0, 128, 1, 2, Ok(()));
+                transfer_item(source, destination, 0, 128, 2, Ok(()));
             }
             #[test_log::test]
             fn test_small_transfer_success() {
@@ -647,8 +641,8 @@ macro_rules! systemsDomainTests {
                     .write(0, &vec![BYTEPATTERN + 1; size])
                     .expect("Writing should succeed");
 
-                let _ = transfer_memory(&mut system_ctx, Arc::from(source1), 0, 0, 128);
-                let _ = transfer_memory(&mut system_ctx, Arc::from(source2), 128, 0, 128);
+                let _ = transfer_memory(&mut system_ctx, &Arc::from(source1), 0, 0, 128);
+                let _ = transfer_memory(&mut system_ctx, &Arc::from(source2), 128, 0, 128);
 
                 let chunk_ref_result = system_ctx.get_chunk_ref(0, 256);
                 match chunk_ref_result {
@@ -695,7 +689,7 @@ macro_rules! systemsDomainTests {
                 let mut second_ctx = acquire::<$domain>($init, 128);
                 transfer_memory(
                     &mut second_ctx,
-                    Arc::from(initial_ctx),
+                    &Arc::from(initial_ctx),
                     0,
                     0,
                     pre_len + body_len,

--- a/machine_interface/src/memory_domain/kvm.rs
+++ b/machine_interface/src/memory_domain/kvm.rs
@@ -532,7 +532,7 @@ pub fn get_transfer_offset(
 
 pub fn transfer_into(
     destination: &mut KvmContext,
-    source: Arc<Context>,
+    source: &Arc<Context>,
     destination_offset: usize,
     source_offset: usize,
     size: usize,

--- a/machine_interface/src/memory_domain/system_domain.rs
+++ b/machine_interface/src/memory_domain/system_domain.rs
@@ -277,7 +277,7 @@ pub fn system_context_transfer(
 ///     (Using this function could cause inconcistencies with fragmented data)
 pub fn into_system_context_transfer(
     destination: &mut SystemContext,
-    source: Arc<Context>,
+    source: &Arc<Context>,
     destination_offset: usize,
     source_offset: usize,
     size: usize,
@@ -329,7 +329,7 @@ pub fn out_of_system_context_transfer(
             DataPosition::ContextStorage(data_arc_context, actual_offset) => {
                 transfer_memory(
                     destination,
-                    data_arc_context.clone(),
+                    data_arc_context,
                     destination_offset + transfered_bytes,
                     *actual_offset,
                     *item_size,

--- a/multinode/src/lib.rs
+++ b/multinode/src/lib.rs
@@ -130,17 +130,7 @@ fn test_serialize_invocation_request() {
             ],
         }),
     ];
-    let context_arc = std::sync::Arc::new(in_context);
-    let inputs = vec![
-        Some(machine_interface::composition::CompositionSet::from((
-            0,
-            vec![context_arc.clone()],
-        ))),
-        Some(machine_interface::composition::CompositionSet::from((
-            1,
-            vec![context_arc.clone()],
-        ))),
-    ];
+    let inputs = machine_interface::composition::CompositionSet::from_context(in_context);
 
     // serialize
     let serialized_sets = util::composition_sets_to_proto(&inputs);
@@ -219,53 +209,38 @@ fn test_serialize_invocation_request() {
 
     let set_0 = sets[0].take().expect("Should have Some(_) for set 0");
     assert_eq!(1, set_0.len());
-    let (item_0_0_set_index, item_0_0_item_index, item_0_0_context) =
-        set_0.into_iter().next().unwrap();
-    let item_0_0_item = &item_0_0_context.content[item_0_0_set_index]
-        .as_ref()
-        .unwrap()
-        .buffers[item_0_0_item_index];
-    assert_eq!(item_0_0_name, item_0_0_item.ident);
-    assert_eq!(0, item_0_0_item.key);
-    assert_eq!(size_of::<u64>(), item_0_0_item.data.size);
+    let (item_0_0, item_0_0_context) = set_0.into_iter().next().unwrap();
+    assert_eq!(item_0_0_name, item_0_0.ident);
+    assert_eq!(0, item_0_0.key);
+    assert_eq!(size_of::<u64>(), item_0_0.data.size);
     assert_eq!(
         &item_0_0_data.to_le_bytes(),
         item_0_0_context
-            .get_chunk_ref(item_0_0_item.data.offset, size_of::<u64>())
+            .get_chunk_ref(item_0_0.data.offset, size_of::<u64>())
             .unwrap()
     );
 
     let set_1 = sets[1].take().expect("Should have Some(_) for set 1");
     assert_eq!(2, set_1.len());
     let mut set_1_iterator = set_1.into_iter();
-    let (item_1_0_set_index, item_1_0_item_index, item_1_0_context) =
-        set_1_iterator.next().unwrap();
-    let item_1_0_item = &item_1_0_context.content[item_1_0_set_index]
-        .as_ref()
-        .unwrap()
-        .buffers[item_1_0_item_index];
-    assert_eq!(item_1_0_name, item_1_0_item.ident);
-    assert_eq!(7, item_1_0_item.key);
-    assert_eq!(size_of::<u64>(), item_1_0_item.data.size);
+    let (item_1_0, item_1_0_context) = set_1_iterator.next().unwrap();
+    assert_eq!(item_1_0_name, item_1_0.ident);
+    assert_eq!(7, item_1_0.key);
+    assert_eq!(size_of::<u64>(), item_1_0.data.size);
     assert_eq!(
         &item_1_0_data.to_le_bytes(),
         item_1_0_context
-            .get_chunk_ref(item_1_0_item.data.offset, size_of::<u64>())
+            .get_chunk_ref(item_1_0.data.offset, size_of::<u64>())
             .unwrap()
     );
-    let (item_1_1_set_index, item_1_1_item_index, item_1_1_context) =
-        set_1_iterator.next().unwrap();
-    let item_1_1_item = &item_1_1_context.content[item_1_1_set_index]
-        .as_ref()
-        .unwrap()
-        .buffers[item_1_1_item_index];
-    assert_eq!(item_1_1_name, item_1_1_item.ident);
-    assert_eq!(14, item_1_1_item.key);
-    assert_eq!(size_of::<u128>(), item_1_1_item.data.size);
+    let (item_1_1, item_1_1_context) = set_1_iterator.next().unwrap();
+    assert_eq!(item_1_1_name, item_1_1.ident);
+    assert_eq!(14, item_1_1.key);
+    assert_eq!(size_of::<u128>(), item_1_1.data.size);
     assert_eq!(
         &item_1_1_data.to_le_bytes(),
         item_1_1_context
-            .get_chunk_ref(item_1_1_item.data.offset, size_of::<u128>())
+            .get_chunk_ref(item_1_1.data.offset, size_of::<u128>())
             .unwrap()
     );
 }

--- a/multinode/src/util.rs
+++ b/multinode/src/util.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 // For types which have the same name for prot and machine_interface,
 // use the full ones to make sure there is no mix ups
 use dandelion_commons::{err_dandelion, DandelionError, DandelionResult, MultinodeError};
@@ -44,7 +42,6 @@ pub fn engine_type_ptod(t: proto::EngineType) -> DandelionResult<machine_config:
 
 /// Takes a `CompositionSet` reference and translates it into a protocol data set.
 pub fn composition_set_to_proto(set: &CompositionSet) -> proto::DataSet {
-    let set_idx = set.get_set_idx();
     let mut items = Vec::with_capacity(set.len());
     for itm_idx in 0..set.len() {
         let (ident, key, data) = set.get_item(itm_idx);
@@ -53,7 +50,7 @@ pub fn composition_set_to_proto(set: &CompositionSet) -> proto::DataSet {
     // assigning name equal to index, as they are ignored on the receiver node anyway
     // so the effort to get the correct name would be wasted.
     proto::DataSet {
-        ident: format!("set_{}", set_idx),
+        ident: set.get_name().clone(),
         items,
     }
 }
@@ -119,10 +116,6 @@ pub fn proto_data_sets_to_context(protobuf_sets: Vec<proto::DataSet>) -> Context
 pub fn proto_data_sets_to_composition_sets(
     proto_sets: Vec<proto::DataSet>,
 ) -> Vec<Option<CompositionSet>> {
-    let num_sets = proto_sets.len();
     let context = proto_data_sets_to_context(proto_sets);
-    let context_arc = Arc::new(context);
-    (0..num_sets)
-        .map(|set_id| Some(CompositionSet::from((set_id, vec![context_arc.clone()]))))
-        .collect::<Vec<_>>()
+    CompositionSet::from_context(context)
 }

--- a/server/src/frontend.rs
+++ b/server/src/frontend.rs
@@ -28,8 +28,7 @@ use machine_interface::{
     composition::CompositionSet,
     function_driver::{Metadata, WorkDone, WorkToDo},
     machine_config::EngineType,
-    memory_domain::{bytes_context::BytesContext, read_only::ReadOnlyContext},
-    DataItem, DataSet, Position,
+    memory_domain::bytes_context::BytesContext,
 };
 use multinode::{
     proto::{Engine, NodeInfo},
@@ -121,32 +120,10 @@ async fn handle_function_registration(
         .input_sets
         .into_iter()
         .map(|(name, data)| {
-            if let Some(static_data) = data {
-                let data_contexts = static_data
-                    .into_iter()
-                    .map(|(item_name, data_vec)| {
-                        let item_size = data_vec.len();
-                        let mut new_context =
-                            ReadOnlyContext::new(data_vec.into_boxed_slice()).unwrap();
-                        new_context.content.push(Some(DataSet {
-                            ident: name.clone(),
-                            buffers: vec![DataItem {
-                                ident: item_name,
-                                data: Position {
-                                    offset: 0,
-                                    size: item_size,
-                                },
-                                key: 0,
-                            }],
-                        }));
-                        Arc::new(new_context)
-                    })
-                    .collect();
-                let composition_set = CompositionSet::from((0, data_contexts));
-                (name, Some(composition_set))
-            } else {
-                (name, None)
-            }
+            (
+                name,
+                data.and_then(|static_data| Some(CompositionSet::from_byte_items(static_data))),
+            )
         })
         .collect();
 
@@ -268,10 +245,11 @@ async fn handle_request(
     // map sets in the order they are in the request
     let request_number = request_context.content.len();
     debug!("Request number of request_context: {}", request_number);
-    let request_arc = Arc::new(request_context);
-    let inputs = (0..request_number)
-        .map(|set_id| {
-            DispatcherInput::Set(CompositionSet::from((set_id, vec![request_arc.clone()])))
+    let inputs = CompositionSet::from_context(request_context)
+        .into_iter()
+        .map(|set_option| match set_option {
+            Some(set) => DispatcherInput::Set(set),
+            None => DispatcherInput::None,
         })
         .collect::<Vec<_>>();
 

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,7 @@ use hyper::body::Frame;
 use machine_interface::{
     composition::CompositionSet,
     memory_domain::{Context, ContextTrait},
+    DataItem,
 };
 use serde::{Deserialize, Serialize};
 use std::{io::IoSlice, sync::Arc};
@@ -43,20 +44,17 @@ pub struct InputItem<'data> {
 struct ItemData {
     response_offset: usize,
     reponse_size: usize,
-    set_index: usize,
-    item_index: usize,
+    data_item: DataItem,
     context: Arc<Context>,
 }
 
 fn encode_item(
-    set_index: usize,
-    item_index: usize,
-    context: Arc<Context>,
+    data_item: &DataItem,
+    context: &Arc<Context>,
     response: &mut Vec<u8>,
     data_items: &mut Vec<ItemData>,
     array_index: usize,
 ) -> usize {
-    let item_ref = &context.content[set_index].as_ref().unwrap().buffers[item_index];
     // add item to array with doc type and index into array as name
     response.push(3);
     response.extend_from_slice(format!("{}", array_index).as_bytes());
@@ -68,7 +66,7 @@ fn encode_item(
     // item identifier to be type string, name identifier and item identifier
     response.push(2);
     response.extend_from_slice("identifier\0".as_bytes());
-    let identifier = &item_ref.ident;
+    let identifier = &data_item.ident;
     response.extend_from_slice(&((identifier.len() + 1) as i32).to_le_bytes());
     response.extend_from_slice(identifier.as_bytes());
     response.push(0);
@@ -76,24 +74,23 @@ fn encode_item(
     // item key to be type int64, name key and item key
     response.push(18);
     response.extend_from_slice("key\0".as_bytes());
-    let key = item_ref.key as i64;
+    let key = data_item.key as i64;
     response.extend_from_slice(&key.to_le_bytes());
 
     // item data to be binary type, name data, with item data
     response.push(5);
     response.extend_from_slice("data\0".as_bytes());
     // binary lenth, generic subtype subtype and then all data
-    let data_size = item_ref.data.size as i32;
+    let data_size = data_item.data.size as i32;
     response.extend_from_slice(&data_size.to_le_bytes());
     response.push(0);
 
-    let item_size = item_ref.data.size;
+    let item_size = data_item.data.size;
     data_items.push(ItemData {
         response_offset: response.len(),
         reponse_size: item_size,
-        set_index,
-        item_index,
-        context,
+        data_item: data_item.clone(),
+        context: context.clone(),
     });
 
     // end doc and set length
@@ -111,16 +108,7 @@ fn encode_sets(
 ) -> usize {
     let mut all_items = 0;
     // filter out empty sets
-    let non_empty_set = sets.into_iter().filter_map(|set| match set {
-        Some(s) => {
-            if s.is_empty() {
-                None
-            } else {
-                Some(s)
-            }
-        }
-        _ => None,
-    });
+    let non_empty_set = sets.into_iter().filter_map(|set| set);
     // if list is empty need to push empty string
     for (index, set) in non_empty_set.enumerate() {
         // add item to array with doc type and name equal to index into the array
@@ -134,9 +122,7 @@ fn encode_sets(
         // set identifier: string type, identifier e_name and actual set name as length, string, null byte
         response.push(2);
         response.extend_from_slice("identifier\0".as_bytes());
-        let mut set_iter = set.into_iter().peekable();
-        let (set_index, _, zero_set) = set_iter.peek().unwrap();
-        let set_name = &zero_set.content[*set_index].as_ref().unwrap().ident;
+        let set_name = set.get_name();
         response.extend_from_slice(&((set_name.len() + 1) as i32).to_le_bytes());
         response.extend_from_slice(set_name.as_bytes());
         response.push(0);
@@ -148,15 +134,8 @@ fn encode_sets(
         response.extend_from_slice(&0i32.to_le_bytes());
 
         let mut set_items_length = 0;
-        for (array_index, (set_index, item_index, context)) in set_iter.enumerate() {
-            set_items_length += encode_item(
-                set_index,
-                item_index,
-                context,
-                response,
-                data_items,
-                array_index,
-            );
+        for (array_index, (data_item, context)) in set.into_iter().enumerate() {
+            set_items_length += encode_item(data_item, context, response, data_items, array_index);
         }
         all_items += set_items_length;
 
@@ -267,11 +246,9 @@ impl DandelionBuf {
                     context,
                     response_offset: _,
                     reponse_size: _,
-                    set_index,
-                    item_index,
+                    data_item,
                 } = &self.items[buf_item_index];
-                let position =
-                    context.content[*set_index].as_ref().unwrap().buffers[*item_index].data;
+                let position = data_item.data;
                 let start = position.offset + (position.size - to_end);
                 context.get_chunk_ref(start, to_end).unwrap()
             }
@@ -500,9 +477,8 @@ fn test_dandelion_body_serialization() {
             },
         }],
     })];
-    let composition_set = CompositionSet::from((0, vec![Arc::new(new_context)]));
-    let context_map = vec![Some(composition_set)];
-    let context_body = DandelionBody::new(context_map, &recorder);
+    let composition_set = CompositionSet::from_context(new_context);
+    let context_body = DandelionBody::new(composition_set, &recorder);
 
     tokio::runtime::Builder::new_current_thread()
         .build()

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -49,8 +49,8 @@ struct ItemData {
 }
 
 fn encode_item(
-    data_item: &DataItem,
-    context: &Arc<Context>,
+    data_item: DataItem,
+    context: Arc<Context>,
     response: &mut Vec<u8>,
     data_items: &mut Vec<ItemData>,
     array_index: usize,
@@ -89,8 +89,8 @@ fn encode_item(
     data_items.push(ItemData {
         response_offset: response.len(),
         reponse_size: item_size,
-        data_item: data_item.clone(),
-        context: context.clone(),
+        data_item,
+        context,
     });
 
     // end doc and set length


### PR DESCRIPTION
Changing from indices into the context content to taking ownership of the content at set creation.
Simplifies the interfaces for downstream users of the set and removes a lot of indexing, unwrapping etc.
As proposed in issue #103