### PR TITLE
Dev/preemption

### DIFF
--- a/dandelion_commons/src/lib.rs
+++ b/dandelion_commons/src/lib.rs
@@ -5,6 +5,13 @@ pub mod records;
 
 pub type FunctionId = Arc<String>;
 
+/// Priority level for work items in the scheduling queue. 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Priority {
+    High,
+    BestEffort,
+}
+
 // TODO define error types, possibly better printing than debug
 // TODO make naming consistent and move groups to subtypes, e.g. DomainError -> Domain in main enum
 #[derive(Debug, Clone, PartialEq)]
@@ -103,6 +110,8 @@ pub enum DandelionError {
     OtherProctionError,
     /// Work queue from the dispatcher to the engines is full
     WorkQueueFull,
+    /// Function execution was preempted before completion
+    Preempted,
 }
 
 // Implement display to be compliant with core::error::Error

--- a/dispatcher/src/dispatcher.rs
+++ b/dispatcher/src/dispatcher.rs
@@ -1,6 +1,6 @@
 use crate::{
     function_registry::{FunctionRegistry, FunctionType},
-    queue::{EngineQueue, WorkQueue},
+    queue::{EngineQueue, Priority, WorkQueue},
     resource_pool::ResourcePool,
 };
 use core::pin::Pin;
@@ -106,8 +106,9 @@ impl Dispatcher {
         inputs: Vec<DispatcherInput>,
         caching: bool,
         start_time: std::time::Instant,
+        priority: Priority,
     ) -> DandelionResult<(Vec<Option<CompositionSet>>, Recorder)> {
-        debug!("Queuing function {}", function_name);
+        debug!("Queuing function {} priority {:?}", function_name, priority);
         let function_id = Arc::new(function_name);
         let recorder = Recorder::new(function_id.clone(), start_time);
 
@@ -124,7 +125,7 @@ impl Dispatcher {
         }
 
         let results = self
-            .queue_function(function_id, input_vec, caching, recorder.get_sub_recorder())
+            .queue_function(function_id, input_vec, caching, recorder.get_sub_recorder(), priority)
             .await?;
 
         return Ok((results, recorder));
@@ -143,6 +144,7 @@ impl Dispatcher {
         inputs: Vec<Option<CompositionSet>>,
         caching: bool,
         mut recorder: Recorder,
+        priority: Priority,
     ) -> DandelionResult<Vec<Option<CompositionSet>>> {
         // build up ready sets
         trace!("queue composition");
@@ -229,6 +231,7 @@ impl Dispatcher {
                 args.output_mapping,
                 caching,
                 recorder.get_sub_recorder(),
+                priority,
             )));
         }
         let num_running_functions = awaited_sets.len();
@@ -299,6 +302,7 @@ impl Dispatcher {
                                 args.output_mapping,
                                 caching,
                                 recorder.get_sub_recorder(),
+                                priority,
                             )));
                             None
                         } else {
@@ -330,6 +334,7 @@ impl Dispatcher {
         output_mapping: Vec<Option<usize>>,
         caching: bool,
         recorder: Recorder,
+        priority: Priority,
     ) -> DandelionResult<(Vec<(usize, Option<CompositionSet>)>, Vec<Recorder>)> {
         trace!(
             "queue function {} sharded and input sets: {:?}",
@@ -357,6 +362,7 @@ impl Dispatcher {
                         ins,
                         caching,
                         new_recorder.get_sub_recorder(),
+                        priority,
                     ));
                     recorders.push(new_recorder);
                     future_box
@@ -373,6 +379,7 @@ impl Dispatcher {
                     vec![],
                     caching,
                     new_recorder.get_sub_recorder(),
+                    priority,
                 )
                 .await
                 .and_then(|result| Ok(vec![result]));
@@ -429,10 +436,11 @@ impl Dispatcher {
         input_sets: Vec<Option<CompositionSet>>,
         caching: bool,
         mut recorder: Recorder,
+        priority: Priority,
     ) -> Pin<
         Box<dyn Future<Output = DandelionResult<Vec<Option<CompositionSet>>>> + 'dispatcher + Send>,
     > {
-        trace!("queueing function with id: {}", function_id);
+        trace!("queueing function with id: {} priority: {:?}", function_id, priority);
         Box::pin(async move {
             // find an engine capable of running the function
             // TODO: think about more distinctions, that allow pushing chains of functions which can be executed by single engine,
@@ -469,7 +477,7 @@ impl Dispatcher {
                         recorder: subrecoder,
                     };
                     recorder.record(RecordPoint::ExecutionQueue);
-                    let context = self.work_queue.do_work(args).await?.get_context();
+                    let context = self.work_queue.do_work(args, priority).await?.get_context();
                     recorder.record(RecordPoint::FutureReturn);
 
                     #[cfg(feature = "log_function_stdio")]
@@ -522,6 +530,7 @@ impl Dispatcher {
                             input_sets,
                             caching,
                             recorder,
+                            priority,
                         )
                         .await;
                 }

--- a/dispatcher/src/dispatcher.rs
+++ b/dispatcher/src/dispatcher.rs
@@ -1,8 +1,9 @@
 use crate::{
     function_registry::{FunctionRegistry, FunctionType},
-    queue::{EngineQueue, Priority, WorkQueue},
+    queue::{EngineQueue, WorkQueue},
     resource_pool::ResourcePool,
 };
+use dandelion_commons::Priority; 
 use core::pin::Pin;
 use dandelion_commons::{
     records::{RecordPoint, Recorder},

--- a/dispatcher/src/queue.rs
+++ b/dispatcher/src/queue.rs
@@ -1,8 +1,9 @@
-use dandelion_commons::DandelionResult;
+use dandelion_commons::{DandelionResult,Priority};
 use log::trace;
 use machine_interface::{
     function_driver::{EngineWorkQueue, WorkDone, WorkToDo},
     machine_config::{EngineType, EnumCount},
+    preemption::PreemptionRegistry, 
     promise::{Debt, PromiseBuffer},
 };
 #[cfg(feature = "spin_queue")]
@@ -12,12 +13,6 @@ use std::{
     fmt,
     sync::{Arc, Mutex},
 };
-
-#[derive(Debug, Clone, Copy)]
-pub enum Priority {
-    High,
-    BestEffort,
-}
 
 pub enum QueueFlag {
     EngineReqwestIO = 0b1,
@@ -46,6 +41,8 @@ struct QueueElement {
     work: WorkToDo,
     /// The Debt content of the queue element
     debt: Debt,
+    /// priority of the work item
+    priority: Priority
 }
 
 #[cfg(feature = "spin_queue")]
@@ -59,9 +56,10 @@ struct AtomicTickets {
 /// check high-priority queue first, falls back to best-effort
 #[derive(Clone)]
 pub struct WorkQueue {
-    high: Arc<Mutex<std::collections::LinkedList<QueueElement>>>,
-    best_effort: Arc<Mutex<std::collections::LinkedList<QueueElement>>>,
+    high: Arc<Mutex<LinkedList<QueueElement>>>,
+    best_effort: Arc<Mutex<LinkedList<QueueElement>>>,
     promise_buffer: PromiseBuffer,
+    preemption_registry: Arc<PreemptionRegistry>,
     #[cfg(feature = "spin_queue")]
     tickets: Arc<Box<[AtomicTickets]>>,
 }
@@ -73,6 +71,7 @@ impl WorkQueue {
             high: Arc::new(Mutex::new(LinkedList::new())),
             best_effort: Arc::new(Mutex::new(LinkedList::new())),
             promise_buffer: PromiseBuffer::init(capacity),
+            preemption_registry: Arc::new(PreemptionRegistry::new()), 
             #[cfg(feature = "spin_queue")]
             tickets: Arc::new(
                 (0..EngineType::COUNT)
@@ -89,12 +88,15 @@ impl WorkQueue {
     /// Pushes the work and debt to the back of the queue and sets the flags accordingly.
     /// Returns an error if the queue is full.
     fn push(&self, work: WorkToDo, debt: Debt, flags: u32, priority: Priority) -> DandelionResult<()> {
-        let element = QueueElement { flags, work, debt };
+        let element = QueueElement { flags, work, debt, priority };
 
         match priority {
             Priority::High => {
                 let mut queue = self.high.lock().expect("High priority queue lock poisoned");
                 queue.push_back(element);
+                drop(queue); // Release lock before signaling
+                // Try to preempt a best-effort thread so it can pick up this high-priority work
+                self.preemption_registry.preempt_one();
             }
             Priority::BestEffort => {
                 let mut queue = self.best_effort.lock().expect("Best effort priority queue lock poisoned");
@@ -105,11 +107,12 @@ impl WorkQueue {
     }
 
     // 
-    fn extract_matching(queue: &mut LinkedList<QueueElement>, engine_flags: u32,) -> Option<(WorkToDo, Debt)> {
+    fn extract_matching(queue: &mut LinkedList<QueueElement>, engine_flags: u32,) -> Option<(WorkToDo, Debt, Priority)> {
+
         queue
             .extract_if(|queue_element| queue_element.flags & engine_flags == engine_flags)
             .next()
-            .map(|queue_element| (queue_element.work, queue_element.debt))
+            .map(|queue_element| (queue_element.work, queue_element.debt, queue_element.priority))
     }
 
     /// Inserts the work into the queue setting the flags according to the supported engines and
@@ -162,7 +165,7 @@ impl WorkQueue {
         &self,
         engine_flags: u32,
         engine_type: EngineType,
-    ) -> Option<(WorkToDo, Debt)> {
+    ) -> Option<(WorkToDo, Debt, Priority)> {
         #[cfg(feature = "spin_queue")]
         {
             let queue_head = self.tickets[engine_type as usize]
@@ -206,7 +209,7 @@ impl WorkQueue {
     }
 
     /// Spins on the queue until it manages to acquire some work that matches the given flags.
-    pub fn get_work(&self, engine_flags: u32, engine_type: EngineType) -> (WorkToDo, Debt) {
+    pub fn get_work(&self, engine_flags: u32, engine_type: EngineType) -> (WorkToDo, Debt, Priority) {
         loop {
             #[cfg(feature = "spin_queue")]
             {
@@ -286,16 +289,25 @@ impl EngineQueue {
             .do_work_flags(work, self.engine_flags, priority)
             .await
     }
+    
+    /// Returns a reference to the preemption registry.
+    pub fn preemption_registry(&self) -> &Arc<PreemptionRegistry> {
+        &self.work_queue.preemption_registry
+    }
 }
 
 impl EngineWorkQueue for EngineQueue {
-    fn get_engine_args(&self) -> (WorkToDo, machine_interface::promise::Debt) {
+    fn get_engine_args(&self) -> (WorkToDo, machine_interface::promise::Debt, Priority) {
         self.work_queue
             .get_work(self.engine_flags, self.engine_type)
     }
 
-    fn try_get_engine_args(&self) -> Option<(WorkToDo, machine_interface::promise::Debt)> {
+    fn try_get_engine_args(&self) -> Option<(WorkToDo, machine_interface::promise::Debt, Priority)> {
         self.work_queue
             .try_get_work(self.engine_flags, self.engine_type)
+    }
+
+    fn preemption_registry(&self) -> &Arc<PreemptionRegistry> {
+        &self.work_queue.preemption_registry
     }
 }

--- a/dispatcher/src/queue.rs
+++ b/dispatcher/src/queue.rs
@@ -13,6 +13,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+#[derive(Debug, Clone, Copy)]
+pub enum Priority {
+    High,
+    BestEffort,
+}
+
 pub enum QueueFlag {
     EngineReqwestIO = 0b1,
     EngineCheri = 0b10,
@@ -50,9 +56,11 @@ struct AtomicTickets {
 
 /// Producers can push new work to the end of the queue using the `push` function.
 /// Consumers can pop elements using the `aquire` function.
+/// check high-priority queue first, falls back to best-effort
 #[derive(Clone)]
 pub struct WorkQueue {
-    inner: Arc<Mutex<std::collections::LinkedList<QueueElement>>>,
+    high: Arc<Mutex<std::collections::LinkedList<QueueElement>>>,
+    best_effort: Arc<Mutex<std::collections::LinkedList<QueueElement>>>,
     promise_buffer: PromiseBuffer,
     #[cfg(feature = "spin_queue")]
     tickets: Arc<Box<[AtomicTickets]>>,
@@ -62,7 +70,8 @@ impl WorkQueue {
     /// Creates a new WorkQueue of given size.
     pub fn init(capacity: usize) -> Self {
         WorkQueue {
-            inner: Arc::new(Mutex::new(LinkedList::new())),
+            high: Arc::new(Mutex::new(LinkedList::new())),
+            best_effort: Arc::new(Mutex::new(LinkedList::new())),
             promise_buffer: PromiseBuffer::init(capacity),
             #[cfg(feature = "spin_queue")]
             tickets: Arc::new(
@@ -79,15 +88,33 @@ impl WorkQueue {
 
     /// Pushes the work and debt to the back of the queue and sets the flags accordingly.
     /// Returns an error if the queue is full.
-    fn push(&self, work: WorkToDo, debt: Debt, flags: u32) -> DandelionResult<()> {
-        let mut queue_guard = self.inner.lock().expect("Work queue lock poisoned");
-        queue_guard.push_back(QueueElement { flags, work, debt });
+    fn push(&self, work: WorkToDo, debt: Debt, flags: u32, priority: Priority) -> DandelionResult<()> {
+        let element = QueueElement { flags, work, debt };
+
+        match priority {
+            Priority::High => {
+                let mut queue = self.high.lock().expect("High priority queue lock poisoned");
+                queue.push_back(element);
+            }
+            Priority::BestEffort => {
+                let mut queue = self.best_effort.lock().expect("Best effort priority queue lock poisoned");
+                queue.push_back(element);
+            }
+        }
         Ok(())
+    }
+
+    // 
+    fn extract_matching(queue: &mut LinkedList<QueueElement>, engine_flags: u32,) -> Option<(WorkToDo, Debt)> {
+        queue
+            .extract_if(|queue_element| queue_element.flags & engine_flags == engine_flags)
+            .next()
+            .map(|queue_element| (queue_element.work, queue_element.debt))
     }
 
     /// Inserts the work into the queue setting the flags according to the supported engines and
     /// awaits the future before returning the result.
-    pub async fn do_work(&self, work: WorkToDo) -> DandelionResult<WorkDone> {
+    pub async fn do_work(&self, work: WorkToDo, priority: Priority) -> DandelionResult<WorkDone> {
         let flags = match &work {
             WorkToDo::Shutdown(engine_type) => get_engine_flag(*engine_type),
             WorkToDo::FunctionArguments {
@@ -108,10 +135,10 @@ impl WorkQueue {
                 flags
             }
         };
-        log::trace!("Enqueueing with flags: {}", flags);
+        log::trace!("Enqueueing with flags: {} priority: {:?}", flags, priority);
 
         let (promise, debt) = self.promise_buffer.get_promise()?;
-        self.push(work, debt, flags)?;
+        self.push(work, debt, flags, priority)?;
 
         return promise.await;
     }
@@ -122,13 +149,15 @@ impl WorkQueue {
         &self,
         work: WorkToDo,
         engine_flags: u32,
+        priority: Priority
     ) -> DandelionResult<WorkDone> {
         let (promise, debt) = self.promise_buffer.get_promise()?;
-        self.push(work, debt, engine_flags)?;
+        self.push(work, debt, engine_flags, priority)?;
         return promise.await;
     }
 
-    /// Tries to acquire some work that matches the given flags starting from the head of the queue.
+    /// Tries to acquire some work that matches the given flags
+    /// check high-prio queue first, falls back to best effort
     pub fn try_get_work(
         &self,
         engine_flags: u32,
@@ -153,11 +182,22 @@ impl WorkQueue {
             }
         }
         // May want to try lock here too, instead of lock, but since we have the ticket, should always succeed on locking
-        let mut queue_guard = self.inner.lock().unwrap();
-        let result = queue_guard
-            .extract_if(|queue_element| queue_element.flags & engine_flags == engine_flags)
-            .next()
-            .map(|queue_element| (queue_element.work, queue_element.debt));
+        // check high-priority first
+        {
+                let mut queue = self.high.lock().unwrap();
+                if let Some(result) = Self::extract_matching(&mut queue, engine_flags) {
+                    #[cfg(feature = "spin_queue")]
+                    self.tickets[engine_type as usize]
+                        .start
+                        .fetch_add(1, Ordering::AcqRel);
+                    return Some(result);
+                }
+        }
+        
+        let result = {
+            let mut queue = self.best_effort.lock().unwrap();
+            Self::extract_matching(&mut queue, engine_flags)
+        };
         #[cfg(feature = "spin_queue")]
         self.tickets[engine_type as usize]
             .start
@@ -181,20 +221,32 @@ impl WorkQueue {
                     core::hint::spin_loop();
                 }
             }
-            let mut queue_guard = self.inner.lock().unwrap();
-            // TODO: use the loading flag of the alternative to check if the function is being loaded and skip it.
-            // Also if we take one that needs to be loaded, mark it as loading in progress.
-            let result = queue_guard
-                .extract_if(|queue_element| queue_element.flags & engine_flags == engine_flags)
-                .next()
-                .map(|queue_element| (queue_element.work, queue_element.debt));
+            // Check high-priority queue first
+            {
+                let mut queue = self.high.lock().unwrap();
+                if let Some(result) = Self::extract_matching(&mut queue, engine_flags) {
+                    #[cfg(feature = "spin_queue")]
+                    self.tickets[engine_type as usize]
+                        .start
+                        .fetch_add(1, Ordering::Release);
+                    return result;
+                }
+            }
+            // Then check best-effort queue
+            {
+                let mut queue = self.best_effort.lock().unwrap();
+                if let Some(result) = Self::extract_matching(&mut queue, engine_flags) {
+                    #[cfg(feature = "spin_queue")]
+                    self.tickets[engine_type as usize]
+                        .start
+                        .fetch_add(1, Ordering::Release);
+                    return result;
+                }
+            }
             #[cfg(feature = "spin_queue")]
             self.tickets[engine_type as usize]
                 .start
                 .fetch_add(1, Ordering::Release);
-            if let Some(result_tupple) = result {
-                return result_tupple;
-            }
         }
     }
 }
@@ -203,8 +255,9 @@ impl fmt::Debug for WorkQueue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "WorkQueue{{ length: {} }}",
-            self.inner.lock().unwrap().len(),
+            "WorkQueue{{ high: {}, best_effort: {} }}",
+            self.high.lock().unwrap().len(),
+            self.best_effort.lock().unwrap().len(),
         )
     }
 }
@@ -228,8 +281,10 @@ impl EngineQueue {
     }
 
     /// Inserts the work into the queue and awaits the result.
-    pub async fn do_work(&self, work: WorkToDo) -> DandelionResult<WorkDone> {
-        self.work_queue.do_work_flags(work, self.engine_flags).await
+    pub async fn do_work(&self, work: WorkToDo, priority: Priority) -> DandelionResult<WorkDone> {
+        self.work_queue
+            .do_work_flags(work, self.engine_flags, priority)
+            .await
     }
 }
 

--- a/dispatcher/tests/dispatcher_tests.rs
+++ b/dispatcher/tests/dispatcher_tests.rs
@@ -1,6 +1,7 @@
 #[cfg(all(test, any(feature = "cheri", feature = "mmu", feature = "kvm")))]
 mod dispatcher_tests {
     mod function_tests;
+    mod preemption_tests;
     mod registry_tests;
 
     use dandelion_commons::FunctionId;

--- a/dispatcher/tests/dispatcher_tests/function_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/function_tests.rs
@@ -1,6 +1,6 @@
 use super::{check_matrix, setup_dispatcher};
-use dandelion_commons::{records::Recorder, FunctionId};
-use dispatcher::{dispatcher::Dispatcher, queue::Priority};
+use dandelion_commons::{records::Recorder, FunctionId, Priority};
+use dispatcher::dispatcher::Dispatcher;
 use machine_interface::{
     composition::{
         Composition, CompositionSet, FunctionDependencies, InputSetDescriptor, ShardingMode,

--- a/dispatcher/tests/dispatcher_tests/function_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/function_tests.rs
@@ -1,6 +1,6 @@
 use super::{check_matrix, setup_dispatcher};
 use dandelion_commons::{records::Recorder, FunctionId};
-use dispatcher::dispatcher::Dispatcher;
+use dispatcher::{dispatcher::Dispatcher, queue::Priority};
 use machine_interface::{
     composition::{
         Composition, CompositionSet, FunctionDependencies, InputSetDescriptor, ShardingMode,
@@ -37,7 +37,7 @@ pub fn single_domain_and_engine_basic<Domain: MemoryDomain>(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_function(function_id, Vec::new(), false, recorder));
+        .block_on(dispatcher.queue_function(function_id, Vec::new(), false, recorder, Priority::BestEffort));
     match result {
         Ok(_) => (),
         Err(err) => panic!("Failed with: {:?}", err),
@@ -86,7 +86,7 @@ pub fn single_domain_and_engine_matmul<Domain: MemoryDomain>(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_function(function_id, inputs, false, recorder));
+        .block_on(dispatcher.queue_function(function_id, inputs, false, recorder, Priority::BestEffort));
     let out_sets = match result {
         Ok(context) => context,
         Err(err) => panic!("Failed with: {:?}", err),
@@ -152,7 +152,7 @@ pub fn composition_single_matmul<Domain: MemoryDomain>(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder));
+        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder, Priority::BestEffort));
     let mut out_contexts = match result {
         Ok(context) => context,
         Err(err) => panic!("Failed with: {:?}", err),
@@ -179,7 +179,7 @@ fn composition_option_helper(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder));
+        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder, Priority::BestEffort));
     let out_contexts = match result {
         Ok(context) => context,
         Err(err) => panic!("Failed with: {:?}", err),
@@ -399,7 +399,7 @@ pub fn composition_parallel_matmul<Domain: MemoryDomain>(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder));
+        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder, Priority::BestEffort));
     let out_vec = match result {
         Ok(v) => v,
         Err(err) => panic!("Failed with: {:?}", err),
@@ -489,7 +489,7 @@ pub fn composition_chain_matmul<Domain: MemoryDomain>(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder));
+        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder, Priority::BestEffort));
     let out_contexts = match result {
         Ok(context) => context,
         Err(err) => panic!("Failed with: {:?}", err),
@@ -686,7 +686,7 @@ pub fn composition_diamond_matmac<Domain: MemoryDomain>(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder));
+        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder, Priority::BestEffort));
     let out_contexts = match result {
         Ok(context) => context,
         Err(err) => panic!("Failed with: {:?}", err),
@@ -826,7 +826,7 @@ pub fn composition_chain_large_matmac<Domain: MemoryDomain>(
     let result = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
-        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder));
+        .block_on(dispatcher.queue_composition(composition, inputs, false, recorder, Priority::BestEffort));
     let out_contexts = match result {
         Ok(context) => context,
         Err(err) => panic!("Failed with: {:?}", err),

--- a/dispatcher/tests/dispatcher_tests/preemption_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/preemption_tests.rs
@@ -1,0 +1,166 @@
+use dandelion_commons::{records::Recorder, FunctionId, Priority};
+use dispatcher::dispatcher::Dispatcher;
+use machine_interface::{
+    composition::CompositionSet,
+    function_driver::{ComputeResource, Metadata},
+    machine_config::{DomainType, EngineType},
+    memory_domain::{read_only::ReadOnlyContext, MemoryResource},
+    DataItem, DataSet, Position,
+};
+use std::{collections::BTreeMap, sync::Arc, time::Instant};
+
+use super::check_matrix;
+use dispatcher::resource_pool::ResourcePool;
+
+const DEFAULT_CONTEXT_SIZE: usize = 0x800_0000; // 128MiB
+
+#[inline]
+fn zero_id() -> FunctionId {
+    Arc::new(0.to_string())
+}
+
+/// Build a CompositionSet containing a square matrix of the given size, filled with 1s.
+fn make_matrix_input(size: u64) -> Vec<Option<CompositionSet>> {
+    let n = size as usize;
+    let mut data = Vec::with_capacity(1 + n * n);
+    data.push(size);
+    for _ in 0..(n * n) {
+        data.push(1u64);
+    }
+    let data_len = data.len();
+    let mut ctx = ReadOnlyContext::new(data.into()).expect("Should create context");
+    ctx.content = vec![Some(DataSet {
+        ident: String::from(""),
+        buffers: vec![DataItem {
+            ident: String::from(""),
+            data: Position {
+                offset: 0,
+                size: data_len * core::mem::size_of::<u64>(),
+            },
+            key: 0,
+        }],
+    })];
+    vec![Some(CompositionSet::from((0, vec![Arc::new(ctx)])))]
+}
+
+/// Set up a dispatcher with a single KVM engine thread.
+fn setup_single_core_dispatcher() -> (Dispatcher, FunctionId) {
+    let mut path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.pop();
+    path.push("machine_interface/tests/data/test_elf_kvm_x86_64_matmul");
+    let path_string = path.to_str().expect("Path should be string").to_string();
+
+    let metadata = Metadata {
+        input_sets: vec![(String::from(""), None)],
+        output_sets: vec![String::from("")],
+    };
+
+    let mut pool_map = BTreeMap::new();
+    pool_map.insert(EngineType::Kvm, vec![ComputeResource::CPU(1)]);
+    let resource_pool = ResourcePool {
+        engine_pool: futures::lock::Mutex::new(pool_map),
+    };
+
+    let memory_resources = vec![(
+        DomainType::Kvm,
+        machine_interface::memory_domain::test_resource::get_resource(
+            MemoryResource::Anonymous { size: 1 << 30 },
+        ),
+    )]
+    .into_iter()
+    .collect();
+
+    let dispatcher =
+        Dispatcher::init(resource_pool, memory_resources).expect("Should init dispatcher");
+    let function_id = Arc::new(String::from("matmul"));
+    dispatcher
+        .insert_function(
+            (*function_id).clone(),
+            EngineType::Kvm,
+            DEFAULT_CONTEXT_SIZE,
+            path_string,
+            metadata,
+        )
+        .expect("Should insert function");
+
+    (dispatcher, function_id)
+}
+
+/// Test that a high-priority request preempts a running best-effort request,
+/// completes first, and the best-effort request also completes after resume.
+#[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+#[test_log::test]
+fn test_preemption_and_resume() {
+    let (dispatcher, function_id) = setup_single_core_dispatcher();
+
+    // Spawn best-effort (large matrix) on a separate OS thread with its own runtime.
+    // This lets it start running on the engine before we submit the HP request.
+    let d_be = Arc::new(dispatcher);
+    let d_hp = d_be.clone();
+    let f_be = function_id.clone();
+    let f_hp = function_id.clone();
+
+    let be_finish_time: Arc<std::sync::Mutex<Option<Instant>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let be_finish_clone = be_finish_time.clone();
+
+    let be_thread = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let inputs = make_matrix_input(256);
+            let recorder = Recorder::new(zero_id(), Instant::now());
+            let result = d_be
+                .queue_function(f_be, inputs, false, recorder, Priority::BestEffort)
+                .await;
+            *be_finish_clone.lock().unwrap() = Some(Instant::now());
+            result
+        })
+    });
+
+    // Wait for the BE task to start executing on the engine thread
+    std::thread::sleep(std::time::Duration::from_millis(190));
+
+    // Submit high-priority (small matrix) on this thread
+    let hp_result = {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let inputs = make_matrix_input(2);
+            let recorder = Recorder::new(zero_id(), Instant::now());
+            d_hp.queue_function(f_hp, inputs, false, recorder, Priority::High)
+                .await
+        })
+    };
+    let hp_finish_time = Instant::now();
+
+    // Wait for the best-effort task to finish
+    let be_result = be_thread.join().expect("BE thread panicked");
+
+    // Both should succeed
+    let hp_sets = hp_result.expect("HP function should succeed");
+    let be_sets = be_result.expect("BE function should succeed after resume");
+
+    // Verify HP output: 2x2 ones * ones^T = [[2, 2], [2, 2]]
+    assert_eq!(1, hp_sets.len());
+    let hp_set = hp_sets[0].as_ref().expect("Should have HP output set");
+    let (_, _, hp_ctx) = hp_set.into_iter().next().unwrap();
+    check_matrix(&hp_ctx, 0, 0, 2, vec![2, 2, 2, 2]);
+
+    // Verify BE output: 128x128 ones * ones^T = each element is 128
+    assert_eq!(1, be_sets.len());
+    let be_set = be_sets[0].as_ref().expect("Should have BE output set");
+    let (_, _, be_ctx) = be_set.into_iter().next().unwrap();
+    let expected: Vec<u64> = vec![256u64; 256 * 256];
+    check_matrix(&be_ctx, 0, 0, 256, expected);
+
+    // Check that HP finished before BE
+    let be_time = be_finish_time.lock().unwrap().expect("BE should have finished");
+    println!("HP finished at: {:?}, BE finished at: {:?}", hp_finish_time, be_time);
+    assert!(
+        hp_finish_time < be_time,
+        "High-priority should finish before best-effort"
+    );
+}

--- a/dispatcher/tests/dispatcher_tests/registry_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/registry_tests.rs
@@ -1,5 +1,6 @@
 use crate::dispatcher_tests::{check_matrix, setup_dispatcher};
 use dandelion_commons::records::Recorder;
+use dispatcher::queue::Priority;
 use machine_interface::{
     composition::CompositionSet,
     function_driver::{ComputeResource, Metadata},
@@ -103,7 +104,7 @@ pub fn single_input_fixed<Domain: MemoryDomain>(
         let result = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap()
-            .block_on(dispatcher.queue_function(function_id.clone(), inputs, false, recorder));
+            .block_on(dispatcher.queue_function(function_id.clone(), inputs, false, recorder, Priority::BestEffort));
         recorder = Recorder::new(function_id.clone(), Instant::now());
         let overwrite_result = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -113,6 +114,7 @@ pub fn single_input_fixed<Domain: MemoryDomain>(
                 overwrite_inputs,
                 false,
                 recorder,
+                Priority::BestEffort,
             ));
         let out_sets = match result {
             Ok(composition_sets) => composition_sets,
@@ -208,7 +210,7 @@ pub fn multiple_input_fixed<Domain: MemoryDomain>(
         let result = tokio::runtime::Builder::new_current_thread()
             .build()
             .unwrap()
-            .block_on(dispatcher.queue_function(function_id.clone(), inputs, false, recorder));
+            .block_on(dispatcher.queue_function(function_id.clone(), inputs, false, recorder, Priority::BestEffort));
         recorder = Recorder::new(function_id.clone(), Instant::now());
         let overwrite_result = tokio::runtime::Builder::new_current_thread()
             .build()
@@ -218,6 +220,7 @@ pub fn multiple_input_fixed<Domain: MemoryDomain>(
                 overwrite_inputs,
                 false,
                 recorder,
+                Priority::BestEffort,
             ));
         let out_sets = match result {
             Ok(composition_sets) => composition_sets,

--- a/dispatcher/tests/dispatcher_tests/registry_tests.rs
+++ b/dispatcher/tests/dispatcher_tests/registry_tests.rs
@@ -1,6 +1,5 @@
 use crate::dispatcher_tests::{check_matrix, setup_dispatcher};
-use dandelion_commons::records::Recorder;
-use dispatcher::queue::Priority;
+use dandelion_commons::{records::Recorder, Priority};
 use machine_interface::{
     composition::CompositionSet,
     function_driver::{ComputeResource, Metadata},

--- a/machine_interface/src/function_driver.rs
+++ b/machine_interface/src/function_driver.rs
@@ -2,10 +2,11 @@ use crate::{
     composition::CompositionSet,
     machine_config::EngineType,
     memory_domain::{Context, MemoryDomain},
+    preemption::PreemptionRegistry,
 };
 extern crate alloc;
 use alloc::sync::Arc;
-use dandelion_commons::{records::Recorder, DandelionResult};
+use dandelion_commons::{records::Recorder, DandelionResult, Priority};
 
 pub mod compute_driver;
 pub mod functions;
@@ -57,12 +58,14 @@ impl WorkDone {
 }
 
 pub trait EngineWorkQueue {
-    fn get_engine_args(&self) -> (WorkToDo, crate::promise::Debt);
-    fn try_get_engine_args(&self) -> Option<(WorkToDo, crate::promise::Debt)>;
+    fn get_engine_args(&self) -> (WorkToDo, crate::promise::Debt, Priority);
+    fn try_get_engine_args(&self) -> Option<(WorkToDo, crate::promise::Debt, Priority)>;
+    /// Returns a reference to the preemption registry for engine thread registration.
+    fn preemption_registry(&self) -> &Arc<PreemptionRegistry>;
 }
 
 impl futures::stream::Stream for &mut (dyn EngineWorkQueue + Send) {
-    type Item = (WorkToDo, crate::promise::Debt);
+    type Item = (WorkToDo, crate::promise::Debt, Priority);
     /// By default the behaviour of the work queue on polling is to call try_get_engine_args()
     /// If the call returns Some(tuple), the poll will returns Ready(tuple)
     /// Otherwise the poll function will call the waker and return pending.

--- a/machine_interface/src/function_driver/compute_driver/kvm.rs
+++ b/machine_interface/src/function_driver/compute_driver/kvm.rs
@@ -416,9 +416,10 @@ impl KvmLoop {
 
         debug!("Resuming preempted function");
 
-        // Clear the preemption flag before re-entering
-        self.preempt_flag.store(false, Ordering::Release);
-
+        // Do not clear the preemption flag here.
+        // The caller clears stale flags after deregistering; clearing in resume() would
+        // lose a fresh preemption request that arrives after re-registration but before
+        // the next VM entry.
         let mut preempted = false;
         loop {
             if self.preempt_flag.load(Ordering::Acquire) {

--- a/machine_interface/src/function_driver/compute_driver/kvm.rs
+++ b/machine_interface/src/function_driver/compute_driver/kvm.rs
@@ -246,9 +246,6 @@ struct KvmLoop {
             dump_regs(&self.vcpu);
         }
 
-        // Clear the preemption flag before starting execution
-        self.preempt_flag.store(false, Ordering::Release);
-
         // start running the function
         // TODO: on unexpected break, mark function as failure
         let mut preempted = false;
@@ -260,7 +257,20 @@ struct KvmLoop {
                 break;
             }
 
-            let reason = self.vcpu.run().unwrap();
+            let reason = match self.vcpu.run() {
+                Ok(exit) => exit,
+                Err(e) if e.errno() == libc::EINTR => {
+                    if self.preempt_flag.load(Ordering::Acquire) {
+                        debug!("vcpu.run() returned EINTR with preemption flag set — preempting");
+                        preempted = true;
+                        break;
+                    }
+                    debug!("vcpu.run() returned EINTR but no preemption requested, re-entering");
+                    continue;
+                }
+                Err(e) => panic!("vcpu.run() failed unexpectedly: {:?}", e),
+            };
+
             match reason {
                 #[cfg(feature = "backend_debug")]
                 VcpuExit::IoOut(14, _) => {
@@ -417,7 +427,20 @@ impl KvmLoop {
                 break;
             }
 
-            let reason = self.vcpu.run().unwrap();
+            let reason = match self.vcpu.run() {
+                Ok(exit) => exit,
+                Err(e) if e.errno() == libc::EINTR => {
+                    if self.preempt_flag.load(Ordering::Acquire) {
+                        debug!("vcpu.run() returned EINTR with preemption flag set — preempting");
+                        preempted = true;
+                        break;
+                    }
+                    debug!("vcpu.run() returned EINTR but no preemption requested, re-entering");
+                    continue;
+                }
+                Err(e) => panic!("vcpu.run() failed unexpectedly: {:?}", e),
+            };
+
             match reason {
                 VcpuExit::IoOut(32, _) => {
                     break;

--- a/machine_interface/src/function_driver/compute_driver/kvm.rs
+++ b/machine_interface/src/function_driver/compute_driver/kvm.rs
@@ -16,7 +16,13 @@ use kvm_bindings::{kvm_userspace_memory_region, KVM_MAX_CPUID_ENTRIES, KVM_MEM_L
 use kvm_ioctls::{Kvm, VcpuExit, VcpuFd, VmFd};
 use log::debug;
 use nix::sys::mman::{mmap, MapFlags, ProtFlags};
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
@@ -61,9 +67,24 @@ struct KvmLoop {
     vm: VmFd,
     vcpu: VcpuFd,
     state: ResetState,
+    /// Flag that can be set from outside to request preemption of the running function.
+    /// When true, the run loop will exit at the next VM exit boundary and return DandelionError::Preempted.
+    preempt_flag: Arc<AtomicBool>,
 }
 
-impl EngineLoop for KvmLoop {
+impl KvmLoop {
+    /// Returns a clone of the preemption flag handle.
+    pub fn get_preempt_flag(&self) -> Arc<AtomicBool> {
+        self.preempt_flag.clone()
+    }
+
+    /// Request preemption of the currently running function.
+    pub fn request_preemption(&self) {
+        self.preempt_flag.store(true, Ordering::Release);
+    }
+}
+
+    impl EngineLoop for KvmLoop {
     fn init(_core_id: u8) -> DandelionResult<Box<Self>> {
         let kvm = Kvm::new().unwrap();
         assert_eq!(kvm.get_api_version(), 12);
@@ -78,12 +99,22 @@ impl EngineLoop for KvmLoop {
         }
 
         let state = ResetState::new(&vm, &vcpu);
+        let preempt_flag = Arc::new(AtomicBool::new(false));
 
-        return Ok(Box::new(KvmLoop { vm, vcpu, state }));
+        return Ok(Box::new(KvmLoop {
+            vm,
+            vcpu,
+            state,
+            preempt_flag,
+        }));
     }
 
     fn get_engine_type(&self) -> crate::machine_config::EngineType {
         crate::machine_config::EngineType::Kvm
+    }
+
+    fn get_preempt_flag(&self) -> Option<Arc<AtomicBool>> {
+        Some(self.preempt_flag.clone())
     }
 
     fn run(
@@ -208,9 +239,20 @@ impl EngineLoop for KvmLoop {
             dump_regs(&self.vcpu);
         }
 
+        // Clear the preemption flag before starting execution
+        self.preempt_flag.store(false, Ordering::Release);
+
         // start running the function
         // TODO: on unexpected break, mark function as failure
+        let mut preempted = false;
         loop {
+            // Check the preemption flag before each VM entry, catches requests arriving between VM exits
+            if self.preempt_flag.load(Ordering::Acquire) {
+                debug!("Preemption flag set before VM entry, preempting function");
+                preempted = true;
+                break;
+            }
+
             let reason = self.vcpu.run().unwrap();
             match reason {
                 #[cfg(feature = "backend_debug")]
@@ -233,6 +275,16 @@ impl EngineLoop for KvmLoop {
                 VcpuExit::Debug(info) => {
                     debug!("Debug stop: {:?}", info);
                     dump_regs(&self.vcpu);
+                }
+                // VcpuExit::Intr returned when KVM_RUN interrupted by a signal
+                VcpuExit::Intr => {
+                    if self.preempt_flag.load(Ordering::Acquire) {
+                        debug!("KVM_RUN interrupted by signal, preemption flag set — preempting");
+                        preempted = true;
+                        break;
+                    }
+                    // If the flag isn't set, this was a spurious signal — re-enter the guest.
+                    debug!("KVM_RUN interrupted by signal but no preemption requested, re-entering");
                 }
                 r => {
                     debug!("unexpected exit reason: {:?}", r);
@@ -297,6 +349,10 @@ impl EngineLoop for KvmLoop {
             let end = dirty_index * 64 * PAGE_SIZE;
             let start = end - contiguous_pages * PAGE_SIZE;
             kvm_context.insert_into_overlay(start, end, None);
+        }
+
+        if preempted {
+            return Err(DandelionError::Preempted);
         }
 
         read_output_structs::<u64, u64>(&mut context, elf_config.system_data_offset)?;

--- a/machine_interface/src/function_driver/compute_driver/kvm.rs
+++ b/machine_interface/src/function_driver/compute_driver/kvm.rs
@@ -63,6 +63,16 @@ fn step_debug(vcpu: &VcpuFd) {
     })
     .unwrap();
 }
+/// State saved when a function is preempted mid-execution, allowing it to be resumed later.
+/// The VM memory remains attached and the vCPU registers are preserved by KVM,
+/// so resuming just means re-entering the vcpu.run() loop.
+struct SuspendedState {
+    /// The context containing guest memory — kept alive so the VM mapping remains valid.
+    context: Context,
+    /// ELF config needed to read outputs on completion.
+    elf_config: ElfConfig,
+}
+
 struct KvmLoop {
     vm: VmFd,
     vcpu: VcpuFd,
@@ -70,19 +80,11 @@ struct KvmLoop {
     /// Flag that can be set from outside to request preemption of the running function.
     /// When true, the run loop will exit at the next VM exit boundary and return DandelionError::Preempted.
     preempt_flag: Arc<AtomicBool>,
+    /// When a function is preempted, its execution state is saved here so it can be resumed.
+    suspended: Option<SuspendedState>,
 }
 
-impl KvmLoop {
-    /// Returns a clone of the preemption flag handle.
-    pub fn get_preempt_flag(&self) -> Arc<AtomicBool> {
-        self.preempt_flag.clone()
-    }
 
-    /// Request preemption of the currently running function.
-    pub fn request_preemption(&self) {
-        self.preempt_flag.store(true, Ordering::Release);
-    }
-}
 
     impl EngineLoop for KvmLoop {
     fn init(_core_id: u8) -> DandelionResult<Box<Self>> {
@@ -106,6 +108,7 @@ impl KvmLoop {
             vcpu,
             state,
             preempt_flag,
+            suspended: None,
         }));
     }
 
@@ -115,6 +118,10 @@ impl KvmLoop {
 
     fn get_preempt_flag(&self) -> Option<Arc<AtomicBool>> {
         Some(self.preempt_flag.clone())
+    }
+
+    fn resume(&mut self) -> DandelionResult<Context> {
+        KvmLoop::resume(self)
     }
 
     fn run(
@@ -200,7 +207,7 @@ impl KvmLoop {
         }
 
         // attach VM memory
-        let mut region = kvm_userspace_memory_region {
+        let region = kvm_userspace_memory_region {
             slot: 0,
             flags: KVM_MEM_LOG_DIRTY_PAGES,
             guest_phys_addr: 0x0,
@@ -294,12 +301,47 @@ impl KvmLoop {
             }
         }
 
-        let dirty_log = self.vm.get_dirty_log(0, kvm_context.storage.len()).unwrap();
+        // If preempted, save the suspended state so we can resume later.
+        // Keep VM memory attached — the vCPU state is preserved by KVM.
+        if preempted {
+            debug!("Saving suspended state for later resume");
+            self.suspended = Some(SuspendedState {
+                context,
+                elf_config,
+            });
+            return Err(DandelionError::Preempted);
+        }
+
+        // Normal completion — do cleanup and read outputs
+        Self::finish_run(&self.vm, context, elf_config)
+    }
+}
+
+impl KvmLoop {
+    /// Complete a function execution: process dirty log, detach VM memory, read outputs.
+    /// Used both after normal completion and after resuming a preempted function.
+    fn finish_run(
+        vm: &VmFd,
+        mut context: Context,
+        elf_config: ElfConfig,
+    ) -> DandelionResult<Context> {
+        let kvm_context = match &mut context.context {
+            ContextType::Kvm(kvm_context) => kvm_context,
+            _ => return Err(DandelionError::ContextMissmatch),
+        };
+
+        let dirty_log = vm.get_dirty_log(0, kvm_context.storage.len()).unwrap();
 
         // detach VM memory
-        region.memory_size = 0;
+        let region = kvm_userspace_memory_region {
+            slot: 0,
+            flags: KVM_MEM_LOG_DIRTY_PAGES,
+            guest_phys_addr: 0x0,
+            memory_size: 0,
+            userspace_addr: kvm_context.storage.as_ptr() as u64,
+        };
         unsafe {
-            self.vm.set_user_memory_region(region).unwrap();
+            vm.set_user_memory_region(region).unwrap();
         }
 
         let mut dirty_index = 0;
@@ -325,14 +367,12 @@ impl KvmLoop {
                     contiguous_pages = 0;
                 }
                 while trailing_zeros < 64 {
-                    // can always do this, sice if the last one is not a zero it will simply shift by 0
                     local_dirty = local_dirty >> trailing_zeros;
                     bits_processed += trailing_zeros;
                     let trailing_ones = local_dirty.trailing_ones() as usize;
                     contiguous_pages += trailing_ones;
                     local_dirty = local_dirty >> trailing_ones;
                     bits_processed += trailing_ones;
-                    // if the trailing ones were until the end of the u64, break and continue with the next u64
                     if bits_processed >= 64 {
                         break;
                     }
@@ -351,13 +391,72 @@ impl KvmLoop {
             kvm_context.insert_into_overlay(start, end, None);
         }
 
-        if preempted {
-            return Err(DandelionError::Preempted);
-        }
-
         read_output_structs::<u64, u64>(&mut context, elf_config.system_data_offset)?;
         return Ok(context);
     }
+
+    /// Resume a previously preempted function. Re-enters the vcpu.run() loop
+    /// with the VM memory still attached and vCPU state preserved from the last run.
+    /// Returns the completed context on success.
+    pub fn resume(&mut self) -> DandelionResult<Context> {
+        let suspended = self.suspended.take().ok_or_else(|| {
+            debug!("resume() called but no suspended state");
+            DandelionError::EngineError
+        })?;
+
+        debug!("Resuming preempted function");
+
+        // Clear the preemption flag before re-entering
+        self.preempt_flag.store(false, Ordering::Release);
+
+        let mut preempted = false;
+        loop {
+            if self.preempt_flag.load(Ordering::Acquire) {
+                debug!("Preemption flag set before VM re-entry, preempting again");
+                preempted = true;
+                break;
+            }
+
+            let reason = self.vcpu.run().unwrap();
+            match reason {
+                VcpuExit::IoOut(32, _) => {
+                    break;
+                }
+                VcpuExit::SystemEvent(_type, _data) => {
+                    debug!("System Event during resume, type: {}", _type);
+                    break;
+                }
+                VcpuExit::Debug(info) => {
+                    debug!("Debug stop during resume: {:?}", info);
+                    dump_regs(&self.vcpu);
+                }
+                VcpuExit::Intr => {
+                    if self.preempt_flag.load(Ordering::Acquire) {
+                        debug!("KVM_RUN interrupted during resume, preemption flag set — preempting again");
+                        preempted = true;
+                        break;
+                    }
+                    debug!("Spurious signal during resume, re-entering");
+                }
+                r => {
+                    debug!("unexpected exit reason during resume: {:?}", r);
+                    dump_regs(&self.vcpu);
+                    break;
+                }
+            }
+        }
+
+        if preempted {
+            // Preempted again — save state again for another resume later
+            debug!("Function preempted again during resume, saving state");
+            self.suspended = Some(suspended);
+            return Err(DandelionError::Preempted);
+        }
+
+        // Normal completion after resume — do cleanup
+        Self::finish_run(&self.vm, suspended.context, suspended.elf_config)
+    }
+
 }
 
 pub struct KvmDriver {}

--- a/machine_interface/src/function_driver/system_driver/reqwest.rs
+++ b/machine_interface/src/function_driver/system_driver/reqwest.rs
@@ -672,8 +672,8 @@ async fn engine_loop(queue: Box<dyn EngineWorkQueue + Send>) -> Debt {
     let worker_lock = Arc::new(RwLock::new(()));
     loop {
         (tuple, queue_ref) = queue_ref.into_future().await;
-        let (args, debt) = if let Some((tuple_args, tuple_debt)) = tuple {
-            (tuple_args, tuple_debt)
+        let (args, debt, _priority) = if let Some((tuple_args, tuple_debt, tuple_priority)) = tuple {
+            (tuple_args, tuple_debt, tuple_priority)
         } else {
             panic!("Workqueue poll next returned none")
         };

--- a/machine_interface/src/function_driver/test_queue.rs
+++ b/machine_interface/src/function_driver/test_queue.rs
@@ -1,7 +1,9 @@
 use crate::{
     function_driver::{EngineWorkQueue, WorkToDo},
+    preemption::PreemptionRegistry,
     promise::{Debt, Promise, PromiseBuffer},
 };
+use dandelion_commons::Priority;
 use std::sync::{Arc, Condvar, Mutex};
 
 struct TestQueueInternal {
@@ -12,6 +14,7 @@ struct TestQueueInternal {
 pub struct TestQueue {
     internal: Arc<(Mutex<TestQueueInternal>, Condvar)>,
     promise_buffer: PromiseBuffer,
+    preemption_registry: Arc<PreemptionRegistry>,
 }
 
 impl TestQueue {
@@ -19,6 +22,7 @@ impl TestQueue {
         return TestQueue {
             internal: Arc::new((Mutex::new(TestQueueInternal { args: None }), Condvar::new())),
             promise_buffer: PromiseBuffer::init(128),
+            preemption_registry: Arc::new(PreemptionRegistry::new()),
         };
     }
     pub fn enqueu(&self, args: WorkToDo) -> Promise {
@@ -39,7 +43,7 @@ impl TestQueue {
 }
 
 impl EngineWorkQueue for TestQueue {
-    fn get_engine_args(&self) -> (WorkToDo, Debt) {
+    fn get_engine_args(&self) -> (WorkToDo, Debt, Priority) {
         let (lock, arg_var) = self.internal.as_ref();
         let mut lock_guard = lock
             .lock()
@@ -54,10 +58,15 @@ impl EngineWorkQueue for TestQueue {
             .take()
             .expect("Test queue tried to take args from empty queue");
         arg_var.notify_all();
-        return args;
+
+        return (args.0, args.1, Priority::BestEffort);
     }
 
-    fn try_get_engine_args(&self) -> Option<(WorkToDo, crate::promise::Debt)> {
+    fn try_get_engine_args(&self) -> Option<(WorkToDo, crate::promise::Debt, Priority)> {
         return Some(self.get_engine_args());
+    }
+
+    fn preemption_registry(&self) -> &Arc<PreemptionRegistry> {
+        &self.preemption_registry
     }
 }

--- a/machine_interface/src/function_driver/thread_utils.rs
+++ b/machine_interface/src/function_driver/thread_utils.rs
@@ -28,6 +28,116 @@ pub trait EngineLoop {
     fn get_preempt_flag(&self) -> Option<Arc<AtomicBool>> {
         None
     }
+    /// Resume a previously preempted function. Default returns an error (not supported).
+    fn resume(&mut self) -> DandelionResult<Context> {
+        Err(DandelionError::NotImplemented)
+    }
+}
+
+/// Run a single function on the given engine and fulfill the debt with the result.
+/// Used both for normal execution and for running high-priority work on a temporary engine.
+fn run_single_function<E: EngineLoop>(
+    engine: &mut Box<E>,
+    args: WorkToDo,
+    debt: crate::promise::Debt,
+    core_id: u8,
+) {
+    match args {
+        WorkToDo::FunctionArguments {
+            function_alternatives,
+            input_sets,
+            metadata,
+            caching,
+            mut recorder,
+        } => {
+            let engine_type = engine.get_engine_type();
+            let alternative = match function_alternatives
+                .into_iter()
+                .find(|alt| alt.engine == engine_type)
+            {
+                Some(alt) => alt,
+                None => {
+                    drop(recorder);
+                    debt.fulfill(Err(DandelionError::FunctionRegistry(
+                        FunctionRegistryError::UnknownFunctionAlternative,
+                    )));
+                    return;
+                }
+            };
+            let function = match alternative.load_function(caching, &mut recorder) {
+                Ok(func) => func,
+                Err(err) => {
+                    drop(recorder);
+                    debt.fulfill(Err(err));
+                    return;
+                }
+            };
+
+            recorder.record(RecordPoint::LoadStart);
+            let mut function_context =
+                match function.load(&alternative.domain, alternative.context_size) {
+                    Ok(con) => con,
+                    Err(err) => {
+                        drop(recorder);
+                        debt.fulfill(Err(err));
+                        return;
+                    }
+                };
+
+            recorder.record(RecordPoint::TransferStart);
+            function_context.content.reserve(metadata.input_sets.len());
+
+            for (set_index, (input_set_name, static_set)) in
+                metadata.input_sets.iter().enumerate()
+            {
+                let transfer_option = static_set
+                    .as_ref()
+                    .or_else(|| input_sets.get(set_index).and_then(|set| set.as_ref()));
+                let capacity = transfer_option.map_or(0, |set| set.len());
+                function_context.content.push(Some(crate::DataSet {
+                    ident: input_set_name.clone(),
+                    buffers: Vec::with_capacity(capacity),
+                }));
+                if let Some(transfer_set) = transfer_option {
+                    for (source_set_index, source_item_index, source_context) in transfer_set {
+                        if let Err(transfer_error) = memory_domain::transfer_data_item(
+                            &mut function_context,
+                            source_context,
+                            set_index,
+                            128,
+                            input_set_name.as_str(),
+                            source_set_index,
+                            source_item_index,
+                        ) {
+                            drop(recorder);
+                            debt.fulfill(Err(transfer_error));
+                            return;
+                        }
+                    }
+                }
+            }
+
+            recorder.record(RecordPoint::EngineStart);
+            let result = engine.run(
+                function.config.clone(),
+                function_context,
+                &metadata.output_sets,
+            );
+
+            if let Ok(ref context) = result {
+                log::debug!("content: {:?}", context.content);
+            }
+
+            recorder.record(RecordPoint::EngineEnd);
+            drop(recorder);
+
+            let results = result.map(|context| WorkDone::Context(context));
+            debt.fulfill(results);
+        }
+        WorkToDo::Shutdown(_) => {
+            debt.fulfill(Ok(WorkDone::Resources(vec![ComputeResource::CPU(core_id)])));
+        }
+    }
 }
 
 fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
@@ -164,20 +274,83 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                     &metadata.output_sets,
                 );
 
-                // Deregister from preemption registry before fulfilling the debt
+                // Deregister from preemption registry before fulfilling the debt.
+                // Also clear the preempt flag to handle the race condition where a signal
+                // arrives right as the task finishes (between vcpu.run() returning and
+                // deregistering). The empty signal handler won't cause harm, but we need
+                // the flag cleared so it doesn't affect the next task.
                 if registered {
                     registry.deregister(thread_id);
+                    if let Some(ref flag) = preempt_flag {
+                        flag.store(false, std::sync::atomic::Ordering::Release);
+                    }
                 }
 
-                if let Ok(ref context) = result {
-                    log::debug!("content: {:?}", context.content);
+                match result {
+                    Err(DandelionError::Preempted) => {
+                        // Function was preempted — don't fulfill the debt yet.
+                        // The engine_state (KvmLoop) holds the suspended VM state internally.
+                        log::debug!("Best-effort function preempted, handling high-priority work");
+                        drop(recorder);
+
+                        // Create a fresh engine for the high-priority function.
+                        // This gives us a new VM + vCPU while the original's state is preserved.
+                        let mut hp_engine = E::init(core_id)
+                            .expect("Failed to initialize temporary engine for high-priority work");
+
+                        // Grab the high-priority work from the queue (blocking).
+                        // The work is already queued — push() happens before the preemption signal.
+                        let (hp_args, hp_debt, _hp_priority) = queue.get_engine_args();
+
+                        // Run the high-priority function on the temporary engine
+                        run_single_function(&mut hp_engine, hp_args, hp_debt, core_id);
+
+                        // Drop the temporary engine — its VM + vCPU are freed
+                        drop(hp_engine);
+
+                        // Now resume the preempted best-effort function on the original engine.
+                        // The original KvmLoop still has VM memory attached and vCPU state preserved.
+                        log::debug!("Resuming preempted best-effort function");
+
+                        // Re-register with preemption registry since we're running best-effort again
+                        let re_registered = if let Some(ref flag) = preempt_flag {
+                            registry.register(thread_id, flag.clone());
+                            true
+                        } else {
+                            false
+                        };
+
+                        let resume_result = engine_state.resume();
+
+                        // Deregister after resume completes
+                        if re_registered {
+                            registry.deregister(thread_id);
+                        }
+
+                        match resume_result {
+                            Ok(ref context) => {
+                                log::debug!("Resumed content: {:?}", context.content);
+                            }
+                            Err(ref e) => {
+                                log::debug!("Resume failed: {:?}", e);
+                            }
+                        }
+                        let resume_results = resume_result.map(|ctx| WorkDone::Context(ctx));
+                        debt.fulfill(resume_results);
+                    }
+                    Ok(ref context) => {
+                        log::debug!("content: {:?}", context.content);
+                        recorder.record(RecordPoint::EngineEnd);
+                        drop(recorder);
+                        debt.fulfill(result.map(|ctx| WorkDone::Context(ctx)));
+                    }
+                    Err(ref _e) => {
+                        // Some other error (not preemption)
+                        recorder.record(RecordPoint::EngineEnd);
+                        drop(recorder);
+                        debt.fulfill(result.map(|ctx| WorkDone::Context(ctx)));
+                    }
                 }
-
-                recorder.record(RecordPoint::EngineEnd);
-                drop(recorder);
-
-                let results = result.and_then(|context| Ok(WorkDone::Context(context)));
-                debt.fulfill(results);
             }
             WorkToDo::Shutdown(_) => {
                 debt.fulfill(Ok(WorkDone::Resources(vec![ComputeResource::CPU(core_id)])));

--- a/machine_interface/src/function_driver/thread_utils.rs
+++ b/machine_interface/src/function_driver/thread_utils.rs
@@ -4,11 +4,13 @@ use crate::{
     },
     machine_config::EngineType,
     memory_domain::{self, Context},
+    preemption,
 };
 use core::marker::Send;
 use dandelion_commons::{
-    records::RecordPoint, DandelionError, DandelionResult, FunctionRegistryError,
+    records::RecordPoint, DandelionError, DandelionResult, FunctionRegistryError, Priority,
 };
+use std::sync::{atomic::AtomicBool, Arc};
 use std::thread::spawn;
 
 extern crate alloc;
@@ -22,6 +24,10 @@ pub trait EngineLoop {
         output_sets: &Vec<String>,
     ) -> DandelionResult<Context>;
     fn get_engine_type(&self) -> EngineType;
+    /// Returns the preemption flag if this engine supports preemption, returns None otherwise
+    fn get_preempt_flag(&self) -> Option<Arc<AtomicBool>> {
+        None
+    }
 }
 
 fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
@@ -31,9 +37,20 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
         return;
     }
     let mut engine_state = E::init(core_id).expect("Failed to initialize thread state");
+
+    // Install signal handler for preemption SIGUSR1.
+    preemption::install_signal_handler();
+    let preempt_flag = engine_state.get_preempt_flag();
+
+    // Get the thread's pthread_t for signal delivery
+    let thread_id = unsafe { libc::pthread_self() };
+
+    // Get the preemption registry from the queue
+    let registry = queue.preemption_registry().clone();
+
     'engine: loop {
         // TODO catch unwind so we can always return an error or shut down gracefully
-        let (args, debt) = queue.get_engine_args();
+        let (args, debt, priority) = queue.get_engine_args();
         match args {
             WorkToDo::FunctionArguments {
                 function_alternatives,
@@ -42,6 +59,19 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                 caching,
                 mut recorder,
             } => {
+                // If running best-effort work and engine supports preemption,
+                // register with the preemption registry so it can be interrupted
+                let registered = if priority == Priority::BestEffort {
+                    if let Some(ref flag) = preempt_flag {
+                        registry.register(thread_id, flag.clone());
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                };
+
                 let engine_type = engine_state.get_engine_type();
                 let alternative = match function_alternatives
                     .into_iter()
@@ -49,6 +79,9 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                 {
                     Some(alt) => alt,
                     None => {
+                        if registered {
+                            registry.deregister(thread_id);
+                        }
                         drop(recorder);
                         debt.fulfill(Err(DandelionError::FunctionRegistry(
                             FunctionRegistryError::UnknownFunctionAlternative,
@@ -59,6 +92,9 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                 let function = match alternative.load_function(caching, &mut recorder) {
                     Ok(func) => func,
                     Err(err) => {
+                        if registered {
+                            registry.deregister(thread_id);
+                        }
                         drop(recorder);
                         debt.fulfill(Err(err));
                         continue;
@@ -70,6 +106,9 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                     match function.load(&alternative.domain, alternative.context_size) {
                         Ok(con) => con,
                         Err(err) => {
+                            if registered {
+                                registry.deregister(thread_id);
+                            }
                             drop(recorder);
                             debt.fulfill(Err(err));
                             continue;
@@ -106,6 +145,9 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                             );
 
                             if let Err(transfer_error) = transfer_result {
+                                if registered {
+                                    registry.deregister(thread_id);
+                                }
                                 drop(recorder);
                                 debt.fulfill(Err(transfer_error));
                                 continue 'engine;
@@ -121,6 +163,11 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                     function_context,
                     &metadata.output_sets,
                 );
+
+                // Deregister from preemption registry before fulfilling the debt
+                if registered {
+                    registry.deregister(thread_id);
+                }
 
                 if let Ok(ref context) = result {
                     log::debug!("content: {:?}", context.content);

--- a/machine_interface/src/function_driver/thread_utils.rs
+++ b/machine_interface/src/function_driver/thread_utils.rs
@@ -10,7 +10,10 @@ use core::marker::Send;
 use dandelion_commons::{
     records::RecordPoint, DandelionError, DandelionResult, FunctionRegistryError, Priority,
 };
-use std::sync::{atomic::AtomicBool, Arc};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::thread::spawn;
 
 extern crate alloc;
@@ -140,6 +143,110 @@ fn run_single_function<E: EngineLoop>(
     }
 }
 
+/// Register the current engine thread as running best-effort work so a high-priority
+/// arrival can interrupt it.
+fn register_preemptible_thread(
+    registry: &Arc<preemption::PreemptionRegistry>,
+    thread_id: libc::pthread_t,
+    preempt_flag: &Option<Arc<AtomicBool>>,
+) -> bool {
+    if let Some(flag) = preempt_flag {
+        registry.register(thread_id, flag.clone());
+        true
+    } else {
+        false
+    }
+}
+
+/// Deregister the current engine thread and clear any stale preemption flag.
+///
+/// Clearing the flag here avoids carrying an old preemption request into the next task or
+/// resume attempt, while still preserving any request that arrives after the next registration.
+fn deregister_preemptible_thread(
+    registry: &Arc<preemption::PreemptionRegistry>,
+    thread_id: libc::pthread_t,
+    preempt_flag: &Option<Arc<AtomicBool>>,
+    registered: bool,
+) {
+    if registered {
+        registry.deregister(thread_id);
+        if let Some(flag) = preempt_flag {
+            flag.store(false, Ordering::Release);
+        }
+    }
+}
+
+/// Handle a preempted best-effort function by repeatedly:
+/// 1. running the next high-priority task on a temporary engine,
+/// 2. re-registering the original engine thread for preemption,
+/// 3. resuming the best-effort function.
+///
+/// If the resume itself is preempted again, the loop repeats until the best-effort function
+/// finally completes or returns a non-preemption error.
+fn finish_preempted_best_effort<E: EngineLoop>(
+    engine_state: &mut Box<E>,
+    queue: &dyn EngineWorkQueue,
+    debt: crate::promise::Debt,
+    core_id: u8,
+    registry: &Arc<preemption::PreemptionRegistry>,
+    thread_id: libc::pthread_t,
+    preempt_flag: &Option<Arc<AtomicBool>>,
+) {
+    loop {
+        log::debug!("Best-effort function preempted, handling high-priority work");
+
+        // Create a fresh engine for the high-priority function.
+        // This gives us a new VM + vCPU while the original's state is preserved.
+        let mut hp_engine =
+            E::init(core_id).expect("Failed to initialize temporary engine for high-priority work");
+
+        // Grab the high-priority work from the queue (blocking).
+        // The work is already queued — push() happens before the preemption signal.
+        let (hp_args, hp_debt, hp_priority) = queue.get_engine_args();
+        debug_assert_eq!(
+            hp_priority,
+            Priority::High,
+            "Expected high-priority work while servicing a preempted best-effort task"
+        );
+
+        // Run the high-priority function on the temporary engine.
+        run_single_function(&mut hp_engine, hp_args, hp_debt, core_id);
+
+        // Drop the temporary engine — its VM + vCPU are freed.
+        drop(hp_engine);
+
+        // Now resume the preempted best-effort function on the original engine.
+        // The original engine still has its suspended state preserved.
+        log::debug!("Resuming preempted best-effort function");
+
+        let resume_registered = register_preemptible_thread(registry, thread_id, preempt_flag);
+        let resume_result = engine_state.resume();
+        deregister_preemptible_thread(
+            registry,
+            thread_id,
+            preempt_flag,
+            resume_registered,
+        );
+
+        match resume_result {
+            Err(DandelionError::Preempted) => {
+                log::debug!("Best-effort function preempted again during resume");
+                continue;
+            }
+            Ok(ref context) => {
+                log::debug!("Resumed content: {:?}", context.content);
+            }
+            Err(ref e) => {
+                log::debug!("Resume failed: {:?}", e);
+            }
+        }
+
+        let resume_results = resume_result.map(|ctx| WorkDone::Context(ctx));
+        debt.fulfill(resume_results);
+        return;
+    }
+}
+
 fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
     // set core affinity
     if !core_affinity::set_for_current(core_affinity::CoreId { id: core_id.into() }) {
@@ -170,14 +277,9 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                 mut recorder,
             } => {
                 // If running best-effort work and engine supports preemption,
-                // register with the preemption registry so it can be interrupted
+                // register with the preemption registry so it can be interrupted.
                 let registered = if priority == Priority::BestEffort {
-                    if let Some(ref flag) = preempt_flag {
-                        registry.register(thread_id, flag.clone());
-                        true
-                    } else {
-                        false
-                    }
+                    register_preemptible_thread(&registry, thread_id, &preempt_flag)
                 } else {
                     false
                 };
@@ -189,9 +291,12 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                 {
                     Some(alt) => alt,
                     None => {
-                        if registered {
-                            registry.deregister(thread_id);
-                        }
+                        deregister_preemptible_thread(
+                            &registry,
+                            thread_id,
+                            &preempt_flag,
+                            registered,
+                        );
                         drop(recorder);
                         debt.fulfill(Err(DandelionError::FunctionRegistry(
                             FunctionRegistryError::UnknownFunctionAlternative,
@@ -202,9 +307,12 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                 let function = match alternative.load_function(caching, &mut recorder) {
                     Ok(func) => func,
                     Err(err) => {
-                        if registered {
-                            registry.deregister(thread_id);
-                        }
+                        deregister_preemptible_thread(
+                            &registry,
+                            thread_id,
+                            &preempt_flag,
+                            registered,
+                        );
                         drop(recorder);
                         debt.fulfill(Err(err));
                         continue;
@@ -216,9 +324,12 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                     match function.load(&alternative.domain, alternative.context_size) {
                         Ok(con) => con,
                         Err(err) => {
-                            if registered {
-                                registry.deregister(thread_id);
-                            }
+                            deregister_preemptible_thread(
+                                &registry,
+                                thread_id,
+                                &preempt_flag,
+                                registered,
+                            );
                             drop(recorder);
                             debt.fulfill(Err(err));
                             continue;
@@ -255,9 +366,12 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                             );
 
                             if let Err(transfer_error) = transfer_result {
-                                if registered {
-                                    registry.deregister(thread_id);
-                                }
+                                deregister_preemptible_thread(
+                                    &registry,
+                                    thread_id,
+                                    &preempt_flag,
+                                    registered,
+                                );
                                 drop(recorder);
                                 debt.fulfill(Err(transfer_error));
                                 continue 'engine;
@@ -279,64 +393,22 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                 // arrives right as the task finishes (between vcpu.run() returning and
                 // deregistering). The empty signal handler won't cause harm, but we need
                 // the flag cleared so it doesn't affect the next task.
-                if registered {
-                    registry.deregister(thread_id);
-                    if let Some(ref flag) = preempt_flag {
-                        flag.store(false, std::sync::atomic::Ordering::Release);
-                    }
-                }
+                deregister_preemptible_thread(&registry, thread_id, &preempt_flag, registered);
 
                 match result {
                     Err(DandelionError::Preempted) => {
                         // Function was preempted — don't fulfill the debt yet.
-                        // The engine_state (KvmLoop) holds the suspended VM state internally.
-                        log::debug!("Best-effort function preempted, handling high-priority work");
+                        // The engine_state holds the suspended VM state internally.
                         drop(recorder);
-
-                        // Create a fresh engine for the high-priority function.
-                        // This gives us a new VM + vCPU while the original's state is preserved.
-                        let mut hp_engine = E::init(core_id)
-                            .expect("Failed to initialize temporary engine for high-priority work");
-
-                        // Grab the high-priority work from the queue (blocking).
-                        // The work is already queued — push() happens before the preemption signal.
-                        let (hp_args, hp_debt, _hp_priority) = queue.get_engine_args();
-
-                        // Run the high-priority function on the temporary engine
-                        run_single_function(&mut hp_engine, hp_args, hp_debt, core_id);
-
-                        // Drop the temporary engine — its VM + vCPU are freed
-                        drop(hp_engine);
-
-                        // Now resume the preempted best-effort function on the original engine.
-                        // The original KvmLoop still has VM memory attached and vCPU state preserved.
-                        log::debug!("Resuming preempted best-effort function");
-
-                        // Re-register with preemption registry since we're running best-effort again
-                        let re_registered = if let Some(ref flag) = preempt_flag {
-                            registry.register(thread_id, flag.clone());
-                            true
-                        } else {
-                            false
-                        };
-
-                        let resume_result = engine_state.resume();
-
-                        // Deregister after resume completes
-                        if re_registered {
-                            registry.deregister(thread_id);
-                        }
-
-                        match resume_result {
-                            Ok(ref context) => {
-                                log::debug!("Resumed content: {:?}", context.content);
-                            }
-                            Err(ref e) => {
-                                log::debug!("Resume failed: {:?}", e);
-                            }
-                        }
-                        let resume_results = resume_result.map(|ctx| WorkDone::Context(ctx));
-                        debt.fulfill(resume_results);
+                        finish_preempted_best_effort(
+                            &mut engine_state,
+                            queue.as_ref(),
+                            debt,
+                            core_id,
+                            &registry,
+                            thread_id,
+                            &preempt_flag,
+                        );
                     }
                     Ok(ref context) => {
                         log::debug!("content: {:?}", context.content);
@@ -362,4 +434,261 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
 
 pub fn start_thread<E: EngineLoop>(cpu_slot: u8, queue: Box<dyn EngineWorkQueue + Send>) -> () {
     spawn(move || run_thread::<E>(cpu_slot, queue));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        machine_config::EngineType,
+        memory_domain::{malloc::MallocMemoryDomain, MemoryDomain, MemoryResource},
+        promise::PromiseBuffer,
+    };
+    use std::{
+        cell::RefCell,
+        collections::VecDeque,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Mutex,
+        },
+    };
+
+    fn test_engine_type() -> EngineType {
+        #[cfg(feature = "kvm")]
+        {
+            return EngineType::Kvm;
+        }
+        #[cfg(all(not(feature = "kvm"), feature = "mmu"))]
+        {
+            return EngineType::Process;
+        }
+        #[cfg(all(not(feature = "kvm"), not(feature = "mmu"), feature = "cheri"))]
+        {
+            return EngineType::Cheri;
+        }
+        #[cfg(all(
+            not(feature = "kvm"),
+            not(feature = "mmu"),
+            not(feature = "cheri"),
+            feature = "reqwest_io"
+        ))]
+        {
+            return EngineType::Reqwest;
+        }
+        #[cfg(not(any(
+            feature = "kvm",
+            feature = "mmu",
+            feature = "cheri",
+            feature = "reqwest_io"
+        )))]
+        panic!("thread_utils tests require at least one engine feature");
+    }
+
+    struct ScriptedState {
+        resume_results: Mutex<VecDeque<DandelionResult<Context>>>,
+        resume_calls: AtomicUsize,
+    }
+
+    thread_local! {
+        static TEST_STATE: RefCell<Option<Arc<ScriptedState>>> = RefCell::new(None);
+    }
+
+    struct TestStateGuard;
+
+    impl Drop for TestStateGuard {
+        fn drop(&mut self) {
+            TEST_STATE.with(|slot| {
+                slot.replace(None);
+            });
+        }
+    }
+
+    fn install_test_state(
+        resume_results: Vec<DandelionResult<Context>>,
+    ) -> (Arc<ScriptedState>, TestStateGuard) {
+        let state = Arc::new(ScriptedState {
+            resume_results: Mutex::new(VecDeque::from(resume_results)),
+            resume_calls: AtomicUsize::new(0),
+        });
+
+        TEST_STATE.with(|slot| {
+            assert!(
+                slot.replace(Some(state.clone())).is_none(),
+                "test state already installed"
+            );
+        });
+
+        (state, TestStateGuard)
+    }
+
+    struct ScriptedEngine {
+        state: Arc<ScriptedState>,
+        preempt_flag: Arc<AtomicBool>,
+    }
+
+    impl EngineLoop for ScriptedEngine {
+        fn init(_core_id: u8) -> DandelionResult<Box<Self>> {
+            let state = TEST_STATE.with(|slot| {
+                slot.borrow()
+                    .as_ref()
+                    .cloned()
+                    .expect("scripted engine test state should be installed")
+            });
+            Ok(Box::new(Self {
+                state,
+                preempt_flag: Arc::new(AtomicBool::new(false)),
+            }))
+        }
+
+        fn run(
+            &mut self,
+            _config: FunctionConfig,
+            _context: Context,
+            _output_sets: &Vec<String>,
+        ) -> DandelionResult<Context> {
+            panic!("ScriptedEngine::run should not be called in this test")
+        }
+
+        fn get_engine_type(&self) -> EngineType {
+            test_engine_type()
+        }
+
+        fn get_preempt_flag(&self) -> Option<Arc<AtomicBool>> {
+            Some(self.preempt_flag.clone())
+        }
+
+        fn resume(&mut self) -> DandelionResult<Context> {
+            self.state.resume_calls.fetch_add(1, Ordering::SeqCst);
+            self.state
+                .resume_results
+                .lock()
+                .expect("resume_results lock poisoned")
+                .pop_front()
+                .expect("No scripted resume result available")
+        }
+    }
+
+    struct ScriptedQueue {
+        items: Mutex<VecDeque<(WorkToDo, crate::promise::Debt, Priority)>>,
+        promise_buffer: PromiseBuffer,
+        preemption_registry: Arc<preemption::PreemptionRegistry>,
+    }
+
+    impl ScriptedQueue {
+        fn new() -> Self {
+            Self {
+                items: Mutex::new(VecDeque::new()),
+                promise_buffer: PromiseBuffer::init(8),
+                preemption_registry: Arc::new(preemption::PreemptionRegistry::new()),
+            }
+        }
+
+        fn enqueue(
+            &self,
+            work: WorkToDo,
+            priority: Priority,
+        ) -> crate::promise::Promise {
+            let (promise, debt) = self.promise_buffer.get_promise().unwrap();
+            self.items
+                .lock()
+                .expect("ScriptedQueue items lock poisoned")
+                .push_back((work, debt, priority));
+            promise
+        }
+    }
+
+    impl EngineWorkQueue for ScriptedQueue {
+        fn get_engine_args(&self) -> (WorkToDo, crate::promise::Debt, Priority) {
+            self.items
+                .lock()
+                .expect("ScriptedQueue items lock poisoned")
+                .pop_front()
+                .expect("ScriptedQueue expected queued work")
+        }
+
+        fn try_get_engine_args(&self) -> Option<(WorkToDo, crate::promise::Debt, Priority)> {
+            self.items
+                .lock()
+                .expect("ScriptedQueue items lock poisoned")
+                .pop_front()
+        }
+
+        fn preemption_registry(&self) -> &Arc<preemption::PreemptionRegistry> {
+            &self.preemption_registry
+        }
+    }
+
+    fn make_context() -> Context {
+        let domain = MallocMemoryDomain::init(MemoryResource::None)
+            .expect("Should initialize malloc memory domain");
+        domain
+            .acquire_context(8)
+            .expect("Should allocate scripted test context")
+    }
+
+    #[test_log::test]
+    fn handles_repeated_preemption_while_resuming_best_effort_work() {
+        let core_id = 7;
+        let queue = Box::new(ScriptedQueue::new());
+        let hp_promise_1 = queue.enqueue(WorkToDo::Shutdown(test_engine_type()), Priority::High);
+        let hp_promise_2 = queue.enqueue(WorkToDo::Shutdown(test_engine_type()), Priority::High);
+
+        let promise_buffer = PromiseBuffer::init(1);
+        let (be_promise, be_debt) = promise_buffer.get_promise().unwrap();
+
+        let (state, _guard) = install_test_state(vec![
+            Err(DandelionError::Preempted),
+            Ok(make_context()),
+        ]);
+
+        let mut engine_state =
+            ScriptedEngine::init(core_id).expect("Should initialize scripted engine");
+        let preempt_flag = engine_state
+            .get_preempt_flag()
+            .expect("Scripted engine should expose a preempt flag");
+        let thread_id = unsafe { libc::pthread_self() };
+        let registry = queue.preemption_registry().clone();
+
+        let preempt_flag_option = Some(preempt_flag.clone());
+        finish_preempted_best_effort(
+            &mut engine_state,
+            queue.as_ref(),
+            be_debt,
+            core_id,
+            &registry,
+            thread_id,
+            &preempt_flag_option,
+        );
+
+        assert_eq!(2, state.resume_calls.load(Ordering::SeqCst));
+        assert!(
+            !registry.preempt_one(),
+            "engine thread should be deregistered after resume handling completes"
+        );
+        assert!(
+            !preempt_flag.load(Ordering::Acquire),
+            "stale preemption flags should be cleared after resume handling"
+        );
+
+        match futures::executor::block_on(hp_promise_1).expect("first HP promise should resolve") {
+            WorkDone::Resources(resources) => {
+                assert_eq!(1, resources.len());
+                assert!(matches!(resources[0], ComputeResource::CPU(id) if id == core_id));
+            }
+            _ => panic!("first HP work should return resources for shutdown placeholder"),
+        }
+
+        match futures::executor::block_on(hp_promise_2).expect("second HP promise should resolve") {
+            WorkDone::Resources(resources) => {
+                assert_eq!(1, resources.len());
+                assert!(matches!(resources[0], ComputeResource::CPU(id) if id == core_id));
+            }
+            _ => panic!("second HP work should return resources for shutdown placeholder"),
+        }
+
+        match futures::executor::block_on(be_promise).expect("BE promise should resolve") {
+            WorkDone::Context(_) => {}
+            _ => panic!("best-effort work should finish with a context after repeated resume"),
+        }
+    }
 }

--- a/machine_interface/src/function_driver/thread_utils.rs
+++ b/machine_interface/src/function_driver/thread_utils.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use core::marker::Send;
 use dandelion_commons::{
-    records::RecordPoint, DandelionError, DandelionResult, FunctionRegistryError, Priority,
+    records::{RecordPoint, Recorder},
+    DandelionError, DandelionResult, FunctionRegistryError, Priority,
 };
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -191,6 +192,7 @@ fn finish_preempted_best_effort<E: EngineLoop>(
     registry: &Arc<preemption::PreemptionRegistry>,
     thread_id: libc::pthread_t,
     preempt_flag: &Option<Arc<AtomicBool>>,
+    mut recorder: Recorder,
 ) {
     loop {
         log::debug!("Best-effort function preempted, handling high-priority work");
@@ -220,6 +222,9 @@ fn finish_preempted_best_effort<E: EngineLoop>(
         log::debug!("Resuming preempted best-effort function");
 
         let resume_registered = register_preemptible_thread(registry, thread_id, preempt_flag);
+        // Re-stamp EngineStart so EngineEnd-EngineStart reflects only the last
+        // (resumed) execution segment instead of the fragment-before-preemption.
+        recorder.record(RecordPoint::EngineStart);
         let resume_result = engine_state.resume();
         deregister_preemptible_thread(
             registry,
@@ -241,6 +246,8 @@ fn finish_preempted_best_effort<E: EngineLoop>(
             }
         }
 
+        recorder.record(RecordPoint::EngineEnd);
+        drop(recorder);
         let resume_results = resume_result.map(|ctx| WorkDone::Context(ctx));
         debt.fulfill(resume_results);
         return;
@@ -399,7 +406,8 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                     Err(DandelionError::Preempted) => {
                         // Function was preempted — don't fulfill the debt yet.
                         // The engine_state holds the suspended VM state internally.
-                        drop(recorder);
+                        // recorder is moved into finish_preempted_best_effort so the
+                        // resume cycle can re-record EngineStart/EngineEnd.
                         finish_preempted_best_effort(
                             &mut engine_state,
                             queue.as_ref(),
@@ -408,6 +416,7 @@ fn run_thread<E: EngineLoop>(core_id: u8, queue: Box<dyn EngineWorkQueue>) {
                             &registry,
                             thread_id,
                             &preempt_flag,
+                            recorder,
                         );
                     }
                     Ok(ref context) => {
@@ -650,6 +659,7 @@ mod tests {
         let registry = queue.preemption_registry().clone();
 
         let preempt_flag_option = Some(preempt_flag.clone());
+        let recorder = Recorder::new(Arc::new(0.to_string()), std::time::Instant::now());
         finish_preempted_best_effort(
             &mut engine_state,
             queue.as_ref(),
@@ -658,6 +668,7 @@ mod tests {
             &registry,
             thread_id,
             &preempt_flag_option,
+            recorder,
         );
 
         assert_eq!(2, state.resume_calls.load(Ordering::SeqCst));

--- a/machine_interface/src/function_driver/thread_utils.rs
+++ b/machine_interface/src/function_driver/thread_utils.rs
@@ -152,7 +152,7 @@ fn register_preemptible_thread(
     preempt_flag: &Option<Arc<AtomicBool>>,
 ) -> bool {
     if let Some(flag) = preempt_flag {
-        registry.register(thread_id, flag.clone());
+        registry.register(thread_id, flag.clone(), std::time::Instant::now());
         true
     } else {
         false

--- a/machine_interface/src/lib.rs
+++ b/machine_interface/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod composition;
 pub mod function_driver;
 pub mod memory_domain;
+pub mod preemption;
 pub mod promise;
 
 /// Module contains all the information needed about available engines,

--- a/machine_interface/src/preemption.rs
+++ b/machine_interface/src/preemption.rs
@@ -1,12 +1,6 @@
-// Preemption infrastructure for signaling engine threads to stop running
-//
-// When the queue receives high-priority work, it calls
-// registry.preempt_one(), which:
-// 1. Sets the preemption flag on a registered thread
-// 2. Sends SIGUSR1 to that thread, interrupting vcpu.run()
-//
-// The signal causes vcpu.run() to return VcpuExit::Intr. The run loop
-// checks the preemption flag and returns Err(Preempted).
+// Preemption infrastructure: when high-priority work arrives, the queue calls
+// registry.preempt_one() which sets a flag and sends SIGUSR1 to a best-effort
+// engine thread, causing vcpu.run() to return VcpuExit::Intr.
 
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -16,19 +10,13 @@ use std::sync::{
 use libc::pthread_t;
 use log::debug;
 
-/// Handle for a single engine thread that can be preempted.
 pub struct PreemptionHandle {
-    /// The pthread ID of the engine thread, used to send SIGUSR1.
     pub thread_id: pthread_t,
-    /// The preemption flag shared with the KVM run loop.
-    /// Setting this to `true` causes the run loop to exit at the next check.
     pub preempt_flag: Arc<AtomicBool>,
 }
 
-/// Thread-safe registry of engine threads currently running best-effort work.
-/// Used by the queue to find and preempt a thread when high-priority work arrives.
+/// Registry of engine threads currently running best-effort work.
 pub struct PreemptionRegistry {
-    /// List of currently active (running best-effort) engine thread handles.
     handles: Mutex<Vec<PreemptionHandle>>,
 }
 
@@ -39,56 +27,36 @@ impl PreemptionRegistry {
         }
     }
 
-    /// Register an engine thread as running best-effort work.
-    /// Called by the engine thread when it starts executing a best-effort function.
+    /// Register a thread as running best-effort work.
     pub fn register(&self, thread_id: pthread_t, preempt_flag: Arc<AtomicBool>) {
         let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
         handles.push(PreemptionHandle {
             thread_id,
             preempt_flag,
         });
-        debug!(
-            "Registered preemption handle for thread {:?}, total handles: {}",
-            thread_id,
-            handles.len()
-        );
+        debug!("Registered thread {:?}, total: {}", thread_id, handles.len());
     }
 
-    /// Deregister an engine thread (it finished or was preempted).
-    /// Called by the engine thread when it finishes the current function.
+    /// Deregister a thread (finished or preempted).
     pub fn deregister(&self, thread_id: pthread_t) {
         let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
         handles.retain(|h| h.thread_id != thread_id);
-        debug!(
-            "Deregistered preemption handle for thread {:?}, remaining handles: {}",
-            thread_id,
-            handles.len()
-        );
+        debug!("Deregistered thread {:?}, remaining: {}", thread_id, handles.len());
     }
 
-    /// Preempt one engine thread currently running best-effort work.
-    /// Sets the preemption flag and sends SIGUSR1 to interrupt `vcpu.run()`.
-    /// Returns `true` if a thread was preempted, `false` if none were available.
+    /// Preempt one best-effort thread: set its flag and send SIGUSR1.
     pub fn preempt_one(&self) -> bool {
         let handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
         if let Some(handle) = handles.first() {
-            // Set the preemption flag — the run loop will check this
             handle.preempt_flag.store(true, Ordering::Release);
 
-            // Send SIGUSR1 to the thread to kick it out of vcpu.run()
             let ret = unsafe { libc::pthread_kill(handle.thread_id, libc::SIGUSR1) };
             if ret != 0 {
-                debug!(
-                    "Failed to send SIGUSR1 to thread {:?}, error: {}",
-                    handle.thread_id, ret
-                );
+                debug!("Failed to send SIGUSR1 to thread {:?}, error: {}", handle.thread_id, ret);
                 return false;
             }
 
-            debug!(
-                "Sent preemption signal to thread {:?}",
-                handle.thread_id
-            );
+            debug!("Sent preemption signal to thread {:?}", handle.thread_id);
             return true;
         }
 
@@ -97,18 +65,11 @@ impl PreemptionRegistry {
     }
 }
 
-/// Install the SIGUSR1 signal handler for the current thread.
-/// The handler is intentionally empty — the signal's only purpose is to
-/// interrupt the `vcpu.run()` syscall (KVM_RUN ioctl), causing it to
-/// return with `VcpuExit::Intr`. The actual preemption logic is handled
-/// by the AtomicBool flag check in the run loop.
-///
-/// Must be called once per engine thread, before entering the run loop.
+/// Install empty SIGUSR1 handler. The signal just interrupts vcpu.run() (returns VcpuExit::Intr).
+/// Must be called once per engine thread before entering the run loop.
 pub fn install_signal_handler() {
     unsafe {
         let mut sa: libc::sigaction = std::mem::zeroed();
-        // Empty handler — just needs to exist so the signal is "handled"
-        // rather than using the default action (which would terminate the process)
         sa.sa_sigaction = empty_signal_handler as *const () as usize;
         sa.sa_flags = 0; // No SA_RESTART — we want syscalls to be interrupted
         libc::sigemptyset(&mut sa.sa_mask);
@@ -117,13 +78,8 @@ pub fn install_signal_handler() {
             panic!("Failed to install SIGUSR1 handler: {}", ret);
         }
     }
-    debug!("Installed SIGUSR1 signal handler for preemption");
+    debug!("Installed SIGUSR1 signal handler");
 }
 
-/// Empty signal handler. The signal itself is what matters (interrupting KVM_RUN),
-/// not the handler logic. The preemption flag is already set before the signal is sent.
-extern "C" fn empty_signal_handler(_signum: libc::c_int) {
-    // Intentionally empty.
-    // The preempt_flag AtomicBool is set by preempt_one() BEFORE sending the signal,
-    // so the run loop will see it when it checks after VcpuExit::Intr.
-}
+/// Empty handler — the signal itself is what matters, not the handler logic.
+extern "C" fn empty_signal_handler(_signum: libc::c_int) {}

--- a/machine_interface/src/preemption.rs
+++ b/machine_interface/src/preemption.rs
@@ -1,0 +1,129 @@
+// Preemption infrastructure for signaling engine threads to stop running
+//
+// When the queue receives high-priority work, it calls
+// registry.preempt_one(), which:
+// 1. Sets the preemption flag on a registered thread
+// 2. Sends SIGUSR1 to that thread, interrupting vcpu.run()
+//
+// The signal causes vcpu.run() to return VcpuExit::Intr. The run loop
+// checks the preemption flag and returns Err(Preempted).
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+
+use libc::pthread_t;
+use log::debug;
+
+/// Handle for a single engine thread that can be preempted.
+pub struct PreemptionHandle {
+    /// The pthread ID of the engine thread, used to send SIGUSR1.
+    pub thread_id: pthread_t,
+    /// The preemption flag shared with the KVM run loop.
+    /// Setting this to `true` causes the run loop to exit at the next check.
+    pub preempt_flag: Arc<AtomicBool>,
+}
+
+/// Thread-safe registry of engine threads currently running best-effort work.
+/// Used by the queue to find and preempt a thread when high-priority work arrives.
+pub struct PreemptionRegistry {
+    /// List of currently active (running best-effort) engine thread handles.
+    handles: Mutex<Vec<PreemptionHandle>>,
+}
+
+impl PreemptionRegistry {
+    pub fn new() -> Self {
+        PreemptionRegistry {
+            handles: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Register an engine thread as running best-effort work.
+    /// Called by the engine thread when it starts executing a best-effort function.
+    pub fn register(&self, thread_id: pthread_t, preempt_flag: Arc<AtomicBool>) {
+        let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
+        handles.push(PreemptionHandle {
+            thread_id,
+            preempt_flag,
+        });
+        debug!(
+            "Registered preemption handle for thread {:?}, total handles: {}",
+            thread_id,
+            handles.len()
+        );
+    }
+
+    /// Deregister an engine thread (it finished or was preempted).
+    /// Called by the engine thread when it finishes the current function.
+    pub fn deregister(&self, thread_id: pthread_t) {
+        let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
+        handles.retain(|h| h.thread_id != thread_id);
+        debug!(
+            "Deregistered preemption handle for thread {:?}, remaining handles: {}",
+            thread_id,
+            handles.len()
+        );
+    }
+
+    /// Preempt one engine thread currently running best-effort work.
+    /// Sets the preemption flag and sends SIGUSR1 to interrupt `vcpu.run()`.
+    /// Returns `true` if a thread was preempted, `false` if none were available.
+    pub fn preempt_one(&self) -> bool {
+        let handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
+        if let Some(handle) = handles.first() {
+            // Set the preemption flag — the run loop will check this
+            handle.preempt_flag.store(true, Ordering::Release);
+
+            // Send SIGUSR1 to the thread to kick it out of vcpu.run()
+            let ret = unsafe { libc::pthread_kill(handle.thread_id, libc::SIGUSR1) };
+            if ret != 0 {
+                debug!(
+                    "Failed to send SIGUSR1 to thread {:?}, error: {}",
+                    handle.thread_id, ret
+                );
+                return false;
+            }
+
+            debug!(
+                "Sent preemption signal to thread {:?}",
+                handle.thread_id
+            );
+            return true;
+        }
+
+        debug!("No best-effort threads to preempt");
+        false
+    }
+}
+
+/// Install the SIGUSR1 signal handler for the current thread.
+/// The handler is intentionally empty — the signal's only purpose is to
+/// interrupt the `vcpu.run()` syscall (KVM_RUN ioctl), causing it to
+/// return with `VcpuExit::Intr`. The actual preemption logic is handled
+/// by the AtomicBool flag check in the run loop.
+///
+/// Must be called once per engine thread, before entering the run loop.
+pub fn install_signal_handler() {
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        // Empty handler — just needs to exist so the signal is "handled"
+        // rather than using the default action (which would terminate the process)
+        sa.sa_sigaction = empty_signal_handler as *const () as usize;
+        sa.sa_flags = 0; // No SA_RESTART — we want syscalls to be interrupted
+        libc::sigemptyset(&mut sa.sa_mask);
+        let ret = libc::sigaction(libc::SIGUSR1, &sa, std::ptr::null_mut());
+        if ret != 0 {
+            panic!("Failed to install SIGUSR1 handler: {}", ret);
+        }
+    }
+    debug!("Installed SIGUSR1 signal handler for preemption");
+}
+
+/// Empty signal handler. The signal itself is what matters (interrupting KVM_RUN),
+/// not the handler logic. The preemption flag is already set before the signal is sent.
+extern "C" fn empty_signal_handler(_signum: libc::c_int) {
+    // Intentionally empty.
+    // The preempt_flag AtomicBool is set by preempt_one() BEFORE sending the signal,
+    // so the run loop will see it when it checks after VcpuExit::Intr.
+}

--- a/machine_interface/src/preemption.rs
+++ b/machine_interface/src/preemption.rs
@@ -6,48 +6,115 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
 };
+use std::time::Instant;
 
 use libc::pthread_t;
-use log::debug;
+use log::{debug, info};
 
 pub struct PreemptionHandle {
     pub thread_id: pthread_t,
     pub preempt_flag: Arc<AtomicBool>,
+    pub started_at: Instant,
+    /// Inactive handles stay in the registry so per-thread state (preempt_count)
+    /// survives register/deregister cycles. preempt_one() filters by this flag.
+    pub active: bool,
+    pub preempt_count: u64,
 }
 
-/// Registry of engine threads currently running best-effort work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PreemptionPolicy {
+    LongestRunning,
+    Lifo,
+    Fair,
+}
+
+impl Default for PreemptionPolicy {
+    fn default() -> Self {
+        PreemptionPolicy::LongestRunning
+    }
+}
+
 pub struct PreemptionRegistry {
     handles: Mutex<Vec<PreemptionHandle>>,
+    policy: PreemptionPolicy,
 }
 
 impl PreemptionRegistry {
+    /// Read DANDELION_PREEMPTION_POLICY ("lifo", "longest_running", "fair") and
+    /// fall back to LongestRunning if unset or unrecognised.
     pub fn new() -> Self {
+        let raw = std::env::var("DANDELION_PREEMPTION_POLICY").unwrap_or_default();
+        let policy = match raw.to_ascii_lowercase().as_str() {
+            "lifo" => PreemptionPolicy::Lifo,
+            "longest_running" | "longest" => PreemptionPolicy::LongestRunning,
+            "fair" => PreemptionPolicy::Fair,
+            _ => PreemptionPolicy::default(),
+        };
+        info!("PreemptionRegistry initialised with policy {:?}", policy);
+        Self::with_policy(policy)
+    }
+
+    pub fn with_policy(policy: PreemptionPolicy) -> Self {
         PreemptionRegistry {
             handles: Mutex::new(Vec::new()),
+            policy,
         }
     }
 
-    /// Register a thread as running best-effort work.
-    pub fn register(&self, thread_id: pthread_t, preempt_flag: Arc<AtomicBool>) {
-        let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
-        handles.push(PreemptionHandle {
-            thread_id,
-            preempt_flag,
-        });
-        debug!("Registered thread {:?}, total: {}", thread_id, handles.len());
+    pub fn policy(&self) -> PreemptionPolicy {
+        self.policy
     }
 
-    /// Deregister a thread (finished or preempted).
+    pub fn register(&self, thread_id: pthread_t, preempt_flag: Arc<AtomicBool>, started_at: Instant) {
+        let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
+        if let Some(existing) = handles.iter_mut().find(|h| h.thread_id == thread_id) {
+            existing.preempt_flag = preempt_flag;
+            existing.started_at = started_at;
+            existing.active = true;
+        } else {
+            handles.push(PreemptionHandle {
+                thread_id,
+                preempt_flag,
+                started_at,
+                active: true,
+                preempt_count: 0,
+            });
+        }
+        let active = handles.iter().filter(|h| h.active).count();
+        debug!("Registered thread {:?}, active: {}", thread_id, active);
+    }
+
     pub fn deregister(&self, thread_id: pthread_t) {
         let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
-        handles.retain(|h| h.thread_id != thread_id);
-        debug!("Deregistered thread {:?}, remaining: {}", thread_id, handles.len());
+        if let Some(h) = handles.iter_mut().find(|h| h.thread_id == thread_id) {
+            h.active = false;
+        }
+        let active = handles.iter().filter(|h| h.active).count();
+        debug!("Deregistered thread {:?}, active: {}", thread_id, active);
     }
 
-    /// Preempt one best-effort thread: set its flag and send SIGUSR1.
     pub fn preempt_one(&self) -> bool {
-        let handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
-        if let Some(handle) = handles.first() {
+        let mut handles = self.handles.lock().expect("PreemptionRegistry lock poisoned");
+        let active_idxs: Vec<usize> = (0..handles.len()).filter(|&i| handles[i].active).collect();
+        let chosen_idx: Option<usize> = match self.policy {
+            PreemptionPolicy::LongestRunning => {
+                active_idxs.into_iter().min_by_key(|&i| handles[i].started_at)
+            }
+            PreemptionPolicy::Lifo => {
+                active_idxs.into_iter().max_by_key(|&i| handles[i].started_at)
+            }
+            PreemptionPolicy::Fair => {
+                active_idxs.into_iter().min_by(|&a, &b| {
+                    handles[a].preempt_count
+                        .cmp(&handles[b].preempt_count)
+                        .then_with(|| handles[a].started_at.cmp(&handles[b].started_at))
+                })
+            }
+        };
+
+        if let Some(idx) = chosen_idx {
+            handles[idx].preempt_count += 1;
+            let handle = &handles[idx];
             handle.preempt_flag.store(true, Ordering::Release);
 
             let ret = unsafe { libc::pthread_kill(handle.thread_id, libc::SIGUSR1) };
@@ -56,7 +123,10 @@ impl PreemptionRegistry {
                 return false;
             }
 
-            debug!("Sent preemption signal to thread {:?}", handle.thread_id);
+            debug!(
+                "Sent preemption signal to thread {:?} (policy: {:?}, preempt_count now {})",
+                handle.thread_id, self.policy, handle.preempt_count
+            );
             return true;
         }
 
@@ -65,13 +135,15 @@ impl PreemptionRegistry {
     }
 }
 
-/// Install empty SIGUSR1 handler. The signal just interrupts vcpu.run() (returns VcpuExit::Intr).
-/// Must be called once per engine thread before entering the run loop.
+/// Install empty SIGUSR1 handler. The signal interrupts vcpu.run() (returns
+/// VcpuExit::Intr); the handler itself does nothing. Must be called once per
+/// engine thread before entering the run loop.
 pub fn install_signal_handler() {
     unsafe {
         let mut sa: libc::sigaction = std::mem::zeroed();
         sa.sa_sigaction = empty_signal_handler as *const () as usize;
-        sa.sa_flags = 0; // No SA_RESTART — we want syscalls to be interrupted
+        // No SA_RESTART so syscalls get interrupted.
+        sa.sa_flags = 0;
         libc::sigemptyset(&mut sa.sa_mask);
         let ret = libc::sigaction(libc::SIGUSR1, &sa, std::ptr::null_mut());
         if ret != 0 {
@@ -81,5 +153,4 @@ pub fn install_signal_handler() {
     debug!("Installed SIGUSR1 signal handler");
 }
 
-/// Empty handler — the signal itself is what matters, not the handler logic.
 extern "C" fn empty_signal_handler(_signum: libc::c_int) {}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,12 +1,11 @@
 use core_affinity::{self, CoreId};
 use dandelion_commons::{
     records::{Archive, Recorder},
-    DandelionResult,
+    DandelionResult, Priority
 };
 use dandelion_server::DandelionBody;
 use dispatcher::{
     dispatcher::{Dispatcher, DispatcherInput},
-    queue::Priority,
     resource_pool::ResourcePool,
 };
 use http_body_util::BodyExt;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -6,6 +6,7 @@ use dandelion_commons::{
 use dandelion_server::DandelionBody;
 use dispatcher::{
     dispatcher::{Dispatcher, DispatcherInput},
+    queue::Priority,
     resource_pool::ResourcePool,
 };
 use http_body_util::BodyExt;
@@ -52,6 +53,7 @@ enum DispatcherCommand {
         name: String,
         inputs: Vec<DispatcherInput>,
         is_cold: bool,
+        priority: Priority,
         start_time: Instant,
         callback: oneshot::Sender<DandelionResult<(Vec<Option<CompositionSet>>, Recorder)>>,
     },
@@ -71,6 +73,7 @@ enum DispatcherCommand {
 
 async fn serve_request(
     is_cold: bool,
+    priority: Priority,
     req: Request<Incoming>,
     dispatcher: mpsc::Sender<DispatcherCommand>,
 ) -> Result<Response<DandelionBody>, Infallible> {
@@ -126,6 +129,7 @@ async fn serve_request(
             name: function_name,
             inputs,
             is_cold,
+            priority,
             start_time: start_time.clone(),
             callback,
         })
@@ -328,6 +332,7 @@ async fn service(
         // TODO rename to cold func and hot func, remove matmul, compute, io
         "/register/function" => register_function(req, dispatcher).await,
         "/register/composition" => register_composition(req, dispatcher).await,
+        // Best-effort priority (default, backward compatible)
         "/cold/matmul"
         | "/cold/matmulstore"
         | "/cold/compute"
@@ -335,7 +340,7 @@ async fn service(
         | "/cold/chain_scaling"
         | "/cold/middleware_app"
         | "/cold/compression_app"
-        | "/cold/python_app" => serve_request(true, req, dispatcher).await,
+        | "/cold/python_app" => serve_request(true, Priority::BestEffort, req, dispatcher).await,
         "/hot/matmul"
         | "/hot/matmulstore"
         | "/hot/compute"
@@ -343,7 +348,24 @@ async fn service(
         | "/hot/chain_scaling"
         | "/hot/middleware_app"
         | "/hot/compression_app"
-        | "/hot/python_app" => serve_request(false, req, dispatcher).await,
+        | "/hot/python_app" => serve_request(false, Priority::BestEffort, req, dispatcher).await,
+        // High priority
+        "/cold/high/matmul"
+        | "/cold/high/matmulstore"
+        | "/cold/high/compute"
+        | "/cold/high/io"
+        | "/cold/high/chain_scaling"
+        | "/cold/high/middleware_app"
+        | "/cold/high/compression_app"
+        | "/cold/high/python_app" => serve_request(true, Priority::High, req, dispatcher).await,
+        "/hot/high/matmul"
+        | "/hot/high/matmulstore"
+        | "/hot/high/compute"
+        | "/hot/high/io"
+        | "/hot/high/chain_scaling"
+        | "/hot/high/middleware_app"
+        | "/hot/high/compression_app"
+        | "/hot/high/python_app" => serve_request(false, Priority::High, req, dispatcher).await,
         "/stats" => serve_stats(req).await,
         other_uri => {
             trace!("Received request on {}", other_uri);
@@ -367,12 +389,13 @@ async fn dispatcher_loop(
                 name,
                 inputs,
                 is_cold,
+                priority,
                 start_time,
                 mut callback,
             } => {
-                debug!("Handling function request for function {}", name);
+                debug!("Handling function request for function {} with priority {:?}", name, priority);
                 let function_future =
-                    dispatcher.queue_function_by_name(name, inputs, is_cold, start_time);
+                    dispatcher.queue_function_by_name(name, inputs, is_cold, start_time, priority);
                 spawn(async {
                     select! {
                         function_output = function_future => {


### PR DESCRIPTION
Adding preemption to the KVM backend.
Probably want to make a few more changes before fully merging.
Could also consider first splitting of the preemption mechanism as one PR, since that is generally useful and then looking at the low priority work separately.

One thing to consider is the way interrupts are sent to the running functions.
The "recommended" way in the KVM manual is installing a signal handler, that sets the VM to immediately exit if started.
If the VM is about to start, it will immediately exit, if it has already started, it will exit because of the interrupt handler.
(Documentation here: https://docs.kernel.org/virt/kvm/api.html#the-kvm-run-structure)